### PR TITLE
Adds support for subjective questions

### DIFF
--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -84,7 +84,7 @@
           placeholder="Enter your answer here"
           :isDisabled="isAnswerSubmitted"
           :maxHeightLimit="250"
-          @keypress="checkCharLimit"
+          @keypress="preventKeypressIfApplicable"
           data-test="subjectiveAnswer"
         ></Textarea>
         <!-- character limit -->
@@ -188,13 +188,19 @@ export default defineComponent({
 
     /**
      * returns the background class for an option
+     *
+     * handles the 4 different cases:
+     * - the given option has not been selected
+     * - question is non-survey and given option is the right answer
+     * - question is non-survey and given option is the wrong answer
+     * - question is survey and the given option has been selected
      * @param {Number} optionIndex - index of the option
      */
     function optionBackgroundClass(optionIndex: Number) {
       if (
         !props.isAnswerSubmitted ||
-        typeof props.correctAnswer == "string" ||
-        typeof props.submittedAnswer == "string"
+        typeof props.correctAnswer == "string" || // check for typescript
+        typeof props.submittedAnswer == "string" // check for typescript
       ) {
         return {};
       }
@@ -232,7 +238,7 @@ export default defineComponent({
       state.isImageLoading = true;
     }
 
-    function checkCharLimit(event: KeyboardEvent) {
+    function preventKeypressIfApplicable(event: KeyboardEvent) {
       // checks if character limit is reached in case it is set
       if (!hasCharLimit.value) return;
       if (!charactersLeft.value) event.preventDefault();
@@ -364,7 +370,7 @@ export default defineComponent({
       isOptionMarked,
       selectOption,
       labelClass,
-      checkCharLimit,
+      preventKeypressIfApplicable,
       questionImageAreaClass,
       questionImageContainerClass,
       isQuestionImagePresent,

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -159,12 +159,12 @@ export default defineComponent({
     },
     correctAnswer: {
       default: null,
-      type: Array,
+      type: [String, Array],
     },
     /** answer for the question which has been submitted */
     submittedAnswer: {
       default: null,
-      type: Array,
+      type: [String, Array],
     },
     /** answer for the question which has been entered but not submitted */
     draftAnswer: {
@@ -220,7 +220,13 @@ export default defineComponent({
 
     function optionBackgroundClass(optionIndex: Number) {
       // returns the background class for the option
-      if (!props.isAnswerSubmitted) return {};
+      if (
+        !props.isAnswerSubmitted ||
+        typeof props.correctAnswer == "string" ||
+        typeof props.submittedAnswer == "string"
+      ) {
+        return {};
+      }
 
       if (
         !props.isSurveyQuestion &&

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -149,7 +149,7 @@ export default defineComponent({
     },
     /** the character limit to be used if present */
     maxCharLimit: {
-      default: 0,
+      default: -1,
       type: Number,
     },
     /** data of the image to be shown on a question. Contains URL and alt_text */
@@ -374,6 +374,7 @@ export default defineComponent({
       optionInputType,
       answerContainerClass,
       hasCharLimit,
+      charactersLeft,
       maxCharLimitClass,
     };
   },

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -113,7 +113,9 @@ export default defineComponent({
         // TODO: this is ideally not needed but typescript is giving an error that
         // "currentResponse could be possibly null" without this line, which is
         // not correct as the null case has been handled above.
-        if (currentResponse == null) return;
+        if (currentResponse == null || typeof currentResponse == "string") {
+          return;
+        }
 
         const optionPositionInResponse = currentResponse.indexOf(optionIndex);
         if (optionPositionInResponse != -1) {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -16,6 +16,7 @@
       :submittedAnswer="currentQuestionResponseAnswer"
       :isAnswerSubmitted="isAnswerSubmitted"
       @option-selected="questionOptionSelected"
+      @answer-entered="subjectiveAnswerUpdated"
       data-test="body"
     ></Body>
     <Footer
@@ -150,6 +151,11 @@ export default defineComponent({
       state.localCurrentQuestionIndex -= 1;
     }
 
+    /** update the attempt to the current question - valid for subjective questions */
+    function subjectiveAnswerUpdated(answer: string) {
+      state.draftResponses[props.currentQuestionIndex] = answer;
+    }
+
     onUnmounted(() => {
       // remove listeners
       window.removeEventListener("resize", checkScreenOrientation);
@@ -171,6 +177,9 @@ export default defineComponent({
       () => questionType.value == "checkbox"
     );
     const isQuestionTypeMCQ = computed(() => questionType.value == "mcq");
+    const isQuestionTypeSubjective = computed(
+      () => questionType.value == "subjective"
+    );
 
     const currentQuestionResponse = computed(
       () => props.responses[props.currentQuestionIndex]
@@ -193,7 +202,7 @@ export default defineComponent({
         props.currentQuestionIndex
       ] as DraftResponse;
       if (currentDraftResponse == null) return false;
-      // if (this.isQuestionTypeSubjective) return currentDraftResponse != "";
+      if (isQuestionTypeSubjective.value) return currentDraftResponse != "";
       return currentDraftResponse.length > 0;
     });
 
@@ -213,6 +222,7 @@ export default defineComponent({
       submitQuestion,
       showNextQuestion,
       showPreviousQuestion,
+      subjectiveAnswerUpdated,
       currentQuestion,
       questionType,
       questionCorrectAnswer,

--- a/src/components/UI/Icons/BaseIcon.vue
+++ b/src/components/UI/Icons/BaseIcon.vue
@@ -42,7 +42,7 @@ export default {
       required: true,
     },
     iconClass: {
-      type: String,
+      type: [String, Array],
       default: "",
     },
   },

--- a/src/components/UI/Text/InputText.vue
+++ b/src/components/UI/Text/InputText.vue
@@ -36,6 +36,9 @@ import BaseIcon from "../Icons/BaseIcon.vue";
 
 export default defineComponent({
   name: "InputText",
+  components: {
+    BaseIcon,
+  },
   props: {
     title: {
       default: "",

--- a/src/components/UI/Text/Textarea.vue
+++ b/src/components/UI/Text/Textarea.vue
@@ -22,7 +22,7 @@
 <script lang="ts">
 import InputText from "./InputText.vue";
 import { InputTextValidationConfig } from "../../../types";
-import { PropType, defineComponent, reactive, toRefs } from "vue";
+import { PropType, defineComponent, reactive, toRefs, watch } from "vue";
 
 export default defineComponent({
   components: {
@@ -84,6 +84,7 @@ export default defineComponent({
       }
     }
     function keyPress(event: KeyboardEvent) {
+      console.log("oh yeah");
       // invoked by pressing a key
       context.emit("keypress", event);
     }
@@ -91,6 +92,13 @@ export default defineComponent({
       // invoked by the event keydown
       context.emit("keydown", event);
     }
+
+    watch(
+      () => props.value,
+      (newValue) => {
+        state.localValue = newValue;
+      }
+    );
 
     return {
       ...toRefs(state),

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,8 @@ export interface InputTextValidationConfig {
   invalidMessage: String;
 }
 
-export type DraftResponse = number[] | null;
+export type DraftResponse = number[] | string | null;
 
 export interface SubmittedResponse {
-  answer: number[] | null;
+  answer: number[] | string | null;
 }

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -53,6 +53,15 @@ export default defineComponent({
           max_char_limit: null,
         },
         {
+          type: "subjective",
+          text: "yolo",
+          options: ["", ""],
+          correct_answer: null,
+          image: null,
+          survey: false,
+          max_char_limit: 100,
+        },
+        {
           type: "checkbox",
           text: "efgh",
           options: ["option 1", "option 2", "op3", "option 4"],

--- a/tests/e2e/specs/renders-player.js
+++ b/tests/e2e/specs/renders-player.js
@@ -10,9 +10,52 @@ describe("Player", () => {
     cy.get('[data-test="startQuiz"]').should("exist");
   });
 
-  it("on click of start button on splash screen", () => {
+  it("shows modal upon clicking start button on splash screen", () => {
     cy.get('[data-test="startQuiz"]').trigger("click");
     cy.get('[data-test="splash"]').should("not.exist");
     cy.get('[data-test="modal"]').should("exist");
+  });
+
+  it("neither splash screen nor modal shown when all questions are answered", () => {
+    cy.get('[data-test="startQuiz"]').trigger("click");
+
+    // question 1
+    cy.get('[data-test="modal"]')
+      .get('[data-test="optionSelector-0"]')
+      .trigger("click");
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+    // continue button
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+
+    // question 2
+    cy.get('[data-test="modal"]')
+      .get('[data-test="optionSelector-0"]')
+      .trigger("click");
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+    // continue button
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+
+    // question 3
+    cy.get('[data-test="modal"]')
+      .get('[data-test="optionSelector-0"]')
+      .trigger("click");
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+    // continue button
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+
+    cy.get('[data-test="splash"]').should("not.exist");
+    cy.get('[data-test="modal"]').should("not.exist");
   });
 });

--- a/tests/e2e/specs/renders-player.js
+++ b/tests/e2e/specs/renders-player.js
@@ -33,6 +33,19 @@ describe("Player", () => {
 
     // question 2
     cy.get('[data-test="modal"]')
+      .get('[data-test="subjectiveAnswer"]')
+      .get('[data-test="input"]')
+      .type("abcd");
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+    // continue button
+    cy.get('[data-test="modal"]')
+      .get('[data-test="submitButton"]')
+      .trigger("click");
+
+    // question 3
+    cy.get('[data-test="modal"]')
       .get('[data-test="optionSelector-0"]')
       .trigger("click");
     cy.get('[data-test="modal"]')
@@ -43,7 +56,7 @@ describe("Player", () => {
       .get('[data-test="submitButton"]')
       .trigger("click");
 
-    // question 3
+    // question 4
     cy.get('[data-test="modal"]')
       .get('[data-test="optionSelector-0"]')
       .trigger("click");

--- a/tests/unit/components/Questions/Body.spec.ts
+++ b/tests/unit/components/Questions/Body.spec.ts
@@ -175,4 +175,142 @@ describe("Body.vue", () => {
       ).toContain("bg-gray-200");
     });
   });
+
+  describe("subjective questions", () => {
+    const wrapper = mount(Body, {
+      props: {
+        questionType: "subjective",
+      },
+    });
+
+    it("should render question with default values", () => {
+      expect(
+        wrapper.find('[data-test="optionContainer"]').exists()
+      ).toBeFalsy();
+      expect(
+        wrapper.find('[data-test="subjectiveAnswerContainer"]').exists()
+      ).toBeTruthy();
+    });
+
+    it("renders char limit correctly", async () => {
+      // default
+      expect(
+        wrapper.find('[data-test="charLimitContainer"]').exists()
+      ).toBeFalsy();
+
+      // set char limit
+      const maxCharLimit = 50;
+      await wrapper.setProps({
+        maxCharLimit: maxCharLimit,
+      });
+
+      expect(
+        wrapper.find('[data-test="charLimitContainer"]').exists()
+      ).toBeTruthy();
+      expect(wrapper.find('[data-test="charLimit"]').text()).toBe(
+        String(maxCharLimit)
+      );
+
+      // add input such that chars left = > 0.2 * maxCharLimit
+      const value = "thetest";
+      await wrapper
+        .find('[data-test="subjectiveAnswer"]')
+        .find('[data-test="input"]')
+        .setValue(value);
+      expect(wrapper.vm.charactersLeft).toBe(maxCharLimit - value.length);
+      expect(wrapper.vm.maxCharLimitClass).toBe("text-gray-400");
+
+      // add input such that chars left = < 0.2 * maxCharLimit, > 0.1 * charLimit
+      await wrapper
+        .find('[data-test="subjectiveAnswer"]')
+        .find('[data-test="input"]')
+        .setValue("thetestthetestthetestthetestthetestthetest");
+      expect(wrapper.vm.maxCharLimitClass).toBe("text-yellow-500");
+
+      // add input such that chars left = < 0.1 * maxCharLimit
+      await wrapper
+        .find('[data-test="subjectiveAnswer"]')
+        .find('[data-test="input"]')
+        .setValue("thetestthetestthetestthetestthetestthetestthetest");
+      expect(wrapper.vm.maxCharLimitClass).toBe("text-red-400");
+    });
+
+    it("renders disabled answer input field when answer submitted", async () => {
+      await wrapper.setProps({
+        isAnswerSubmitted: true,
+      });
+
+      expect(
+        (
+          wrapper
+            .find('[data-test="subjectiveAnswer"]')
+            .find('[data-test="input"]').element as HTMLInputElement
+        ).disabled
+      ).toBe(true);
+
+      await wrapper.setProps({
+        isAnswerSubmitted: false,
+      });
+    });
+
+    it("displays the answer when default answer given", async () => {
+      const draftAnswer = "abc";
+      const wrapper = mount(Body, {
+        props: {
+          questionType: "subjective",
+          draftAnswer: draftAnswer,
+        },
+      });
+
+      expect(
+        (
+          wrapper
+            .find('[data-test="subjectiveAnswer"]')
+            .find('[data-test="input"]').element as HTMLInputElement
+        ).value
+      ).toBe(draftAnswer);
+    });
+
+    it("displays the answer when submitted answer given", async () => {
+      const submittedAnswer = "abc";
+      const wrapper = mount(Body, {
+        props: {
+          questionType: "subjective",
+          submittedAnswer: submittedAnswer,
+        },
+      });
+
+      expect(
+        (
+          wrapper
+            .find('[data-test="subjectiveAnswer"]')
+            .find('[data-test="input"]').element as HTMLInputElement
+        ).value
+      ).toBe(submittedAnswer);
+    });
+
+    it("updates the answer through the input field", async () => {
+      const value = "test";
+      await wrapper
+        .find('[data-test="subjectiveAnswer"]')
+        .find('[data-test="input"]')
+        .setValue(value);
+
+      expect(wrapper.vm.subjectiveAnswer).toBe(value);
+    });
+
+    it("corrects the answer when it exceeds the max char limit", async () => {
+      const maxCharLimit = 10;
+      await wrapper.setProps({
+        maxCharLimit: maxCharLimit,
+      });
+
+      const value = "thetestthetest";
+      await wrapper
+        .find('[data-test="subjectiveAnswer"]')
+        .find('[data-test="input"]')
+        .setValue(value);
+      expect(wrapper.vm.subjectiveAnswer).toBe(value.slice(0, maxCharLimit));
+    });
+  });
 });

--- a/tests/unit/components/Questions/QuestionModal.spec.ts
+++ b/tests/unit/components/Questions/QuestionModal.spec.ts
@@ -25,16 +25,13 @@ describe("ItemModal.vue", () => {
       max_char_limit: null,
     },
     {
-      type: "checkbox",
-      text: "ijkl",
-      options: ["", "", ""],
-      correct_answer: [0, 1],
-      image: {
-        url: "https://plio-prod-assets.s3.ap-south-1.amazonaws.com/images/afbxudrmbl.png",
-        alt_text: "some image",
-      },
-      survey: true,
-      max_char_limit: null,
+      type: "subjective",
+      text: "yolo",
+      options: ["", ""],
+      correct_answer: null,
+      image: null,
+      survey: false,
+      max_char_limit: 100,
     },
   ] as Question[];
 
@@ -199,6 +196,55 @@ describe("ItemModal.vue", () => {
           .trigger("click");
 
         expect(wrapper.vm.localCurrentQuestionIndex).toBe(2);
+      });
+    });
+  });
+
+  describe("subjective questions", () => {
+    const questionIndex = 2;
+
+    beforeEach(() => mountWrapper({ currentQuestionIndex: questionIndex }));
+
+    it("entering answer makes answer valid", async () => {
+      // initially answer should be invalid
+      expect(wrapper.vm.isAttemptValid).toBeFalsy();
+
+      // select an option
+      await wrapper.find('[data-test="input"]').setValue("abcd");
+
+      // the answer should now be valid
+      expect(wrapper.vm.isAttemptValid).toBeTruthy();
+    });
+
+    describe("submits question", () => {
+      const answer = "abcd";
+      beforeEach(async () => {
+        await mountWrapper({ currentQuestionIndex: questionIndex });
+
+        // enter answer
+        await wrapper.find('[data-test="input"]').setValue(answer);
+
+        // submit the answer
+        wrapper
+          .find('[data-test="footer"]')
+          .find('[data-test="submitButton"]')
+          .trigger("click");
+      });
+
+      it("responses have been updated", () => {
+        expect(wrapper.vm.localResponses[questionIndex]).toEqual({
+          answer: answer,
+        });
+        expect(wrapper.emitted()).toHaveProperty("submit-question");
+      });
+
+      it("proceeds with question on answering", () => {
+        wrapper
+          .find('[data-test="footer"]')
+          .find('[data-test="submitButton"]')
+          .trigger("click");
+
+        expect(wrapper.vm.localCurrentQuestionIndex).toBe(3);
       });
     });
   });

--- a/tests/unit/components/UI/Text/InputText.spec.ts
+++ b/tests/unit/components/UI/Text/InputText.spec.ts
@@ -1,0 +1,47 @@
+import { mount } from "@vue/test-utils";
+import InputText from "@/components/UI/Text/InputText.vue";
+
+describe("InputText.vue", () => {
+  const wrapper = mount(InputText);
+  it("should render with default values", () => {
+    expect(wrapper).toBeTruthy();
+  });
+
+  it("should render title correctly", async () => {
+    const title = "test title";
+    await wrapper.setProps({
+      title: title,
+    });
+    expect(wrapper.find('[data-test="title"]').text()).toBe(title);
+  });
+
+  it("renders valid messages correctly", async () => {
+    const validation = {
+      enabled: true,
+      isValid: true,
+      validMessage: "valid",
+    };
+    await wrapper.setProps({
+      inputValidation: validation,
+    });
+
+    await expect(wrapper.find('[data-test="validationMessage"]').text()).toBe(
+      validation.validMessage
+    );
+  });
+
+  it("renders invalid messages correctly", async () => {
+    const validation = {
+      enabled: true,
+      isValid: false,
+      invalidMessage: "invalid",
+    };
+    await wrapper.setProps({
+      inputValidation: validation,
+    });
+
+    expect(wrapper.find('[data-test="validationMessage"]').text()).toBe(
+      validation.invalidMessage
+    );
+  });
+});

--- a/tests/unit/components/UI/Text/Textarea.spec.js
+++ b/tests/unit/components/UI/Text/Textarea.spec.js
@@ -1,0 +1,41 @@
+import { mount } from "@vue/test-utils";
+import Textarea from "@/components/UI/Text/Textarea";
+
+describe("Textarea.vue", () => {
+  const wrapper = mount(Textarea);
+  it("should render placeholder correctly", async () => {
+    const placeholder = "test placeholder";
+    await wrapper.setProps({
+      placeholder: placeholder,
+    });
+    expect(wrapper.find('[data-test="input"]').attributes("placeholder")).toBe(
+      placeholder
+    );
+  });
+
+  it("input should get disabled", async () => {
+    await wrapper.setProps({
+      isDisabled: true,
+    });
+    expect(wrapper.find('[data-test="input"]').element.disabled).toBe(true);
+  });
+
+  it("renders value sent through prop", async () => {
+    const value = 10;
+    await wrapper.setProps({
+      value: value,
+    });
+
+    expect(wrapper.find('[data-test="input"]').element.value).toBe(
+      String(value)
+    );
+  });
+
+  it("renders value set through input field", async () => {
+    const value = 10;
+    const input = wrapper.find('[data-test="input"]');
+    await input.setValue(value);
+
+    expect(input.element.value).toBe(String(value));
+  });
+});

--- a/tests/unit/components/UI/Text/Textarea.spec.ts
+++ b/tests/unit/components/UI/Text/Textarea.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import Textarea from "@/components/UI/Text/Textarea";
+import Textarea from "@/components/UI/Text/Textarea.vue";
 
 describe("Textarea.vue", () => {
   const wrapper = mount(Textarea);
@@ -17,7 +17,9 @@ describe("Textarea.vue", () => {
     await wrapper.setProps({
       isDisabled: true,
     });
-    expect(wrapper.find('[data-test="input"]').element.disabled).toBe(true);
+    expect(
+      (wrapper.find('[data-test="input"]').element as HTMLInputElement).disabled
+    ).toBe(true);
   });
 
   it("renders value sent through prop", async () => {
@@ -26,9 +28,9 @@ describe("Textarea.vue", () => {
       value: value,
     });
 
-    expect(wrapper.find('[data-test="input"]').element.value).toBe(
-      String(value)
-    );
+    expect(
+      (wrapper.find('[data-test="input"]').element as HTMLInputElement).value
+    ).toBe(String(value));
   });
 
   it("renders value set through input field", async () => {
@@ -36,6 +38,6 @@ describe("Textarea.vue", () => {
     const input = wrapper.find('[data-test="input"]');
     await input.setValue(value);
 
-    expect(input.element.value).toBe(String(value));
+    expect((input.element as HTMLInputElement).value).toBe(String(value));
   });
 });


### PR DESCRIPTION
## Summary
- adds an InputText component which supports a title, validation for the input in the text and a slot
- adds a Textarea component which uses the InputText component above and adds a `<textarea />` in its slot
- allows subjective as another question type

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Test Responsiveness
  - [ ] Laptop (1200px)
  - [ ] Tablet (760px)
  - [ ] Phone (320px)
- [x] Cross-Browser Testing
  - [ ] Chrome
  - [ ] Firefox
- [ ] ~Local Language Support~
- [ ] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [ ] ~Check for bundle size [here](https://bundlephobia.com/) if adding a package~
  - [x] Added relevant details like Labels/Projects/Milestones etc.
  - [ ] ~If adding or removing any environment variable:~
    - [ ] update `docs/ENV.md`
    - [ ] update Github Workflow files
    - [ ] update the secrets for staging and production
- [ ] Testing
  - [x] Wrote tests
  - [x] Tested locally
  - [x] Tested on staging
  - [ ] Tested on an actual physical phone
  - [ ] Tested on production
- [x] Lighthouse Checks
  - [ ] ~Images have `alt` attributes~
  - [ ] ~Any `<img>` tags have `width` and `height` specified~
  - [ ] ~Any `target="_blank"` links have `rel="noopener"`~
  - [x] Only SVGs are used as images. If PNGs are used, their size has been optimised.
  - [ ] ~Any SVGs without text have their `aria-label` attributes set~
