### PR TITLE
Connecting the backend to the frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VUE_APP_BACKEND=http://127.0.0.1:8000

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Fixes #{issue id}
   - [ ] Comments have been added appropriately
   - [ ] Check for bundle size [here](https://bundlephobia.com/) if adding a package
   - [ ] Added relevant details like Labels/Projects/Milestones etc.
-  - [ ] If adding or removing any environment variable, update `docs/ENV.md`
+  - [ ] If adding or removing any environment variable, update `docs/ENV.md` and `.env.example`.
 - [ ] Testing
   - [ ] Wrote tests
   - [ ] Tested locally

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage/
 # local env files
 .env.local
 .env.*.local
+.env.production
+.env.staging
 
 # Log files
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ A generic player for playing different types of questions (mcq, subjective, imag
   - [Pre-requisites](#pre-requisites)
     - [Pre-commit](#pre-commit)
   - [Installation](#installation)
-  - [Compiles and hot-reloads for development](#compiles-and-hot-reloads-for-development)
-  - [Compiles and minifies for production](#compiles-and-minifies-for-production)
+  - [Compile and setup hot-reloading for development](#compile-and-setup-hot-reloading-for-development)
+  - [Compile and minify for deployment](#compile-and-minify-for-deployment)
+    - [Staging](#staging)
+    - [Production](#production)
   - [Run the unit tests](#run-the-unit-tests)
   - [Run the end-to-end tests](#run-the-end-to-end-tests)
 
@@ -48,18 +50,43 @@ The project uses `pre-commit` for identifying and fixing simple issues before yo
 
 ### Installation
 
+- Install the packages
+
 ```
 npm install
+```
+
+- Install `pre-commit`
+
+```
 pre-commit install
 ```
 
-### Compiles and hot-reloads for development
+- Copy `.env.example` to `.env.local` and set the appropriate values of the environment variables. The list of all environment variables along with their meanings can be found in [ENV.md](./docs/ENV.md)
+
+### Compile and setup hot-reloading for development
 
 ```
 npm run serve
 ```
 
-### Compiles and minifies for production
+### Compile and minify for deployment
+
+#### Staging
+
+- Copy `.env.example` to `.env.staging.local` and set the appropriate values of the environment variables.
+
+- Run the following command
+
+```
+npm run build --mode staging
+```
+
+#### Production
+
+- Copy `.env.example` to `.env.production.local` and set the appropriate values of the environment variables.
+
+- Run the following command
 
 ```
 npm run build

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A generic player for playing different types of questions (mcq, subjective, imag
     - [Pre-commit](#pre-commit)
   - [Installation](#installation)
   - [Compile and setup hot-reloading for development](#compile-and-setup-hot-reloading-for-development)
-  - [Compile and minify for deployment](#compile-and-minify-for-deployment)
+  - [Build for deployment](#build-for-deployment)
     - [Staging](#staging)
     - [Production](#production)
   - [Run the unit tests](#run-the-unit-tests)
@@ -70,11 +70,11 @@ pre-commit install
 npm run serve
 ```
 
-### Compile and minify for deployment
+### Build for deployment
 
 #### Staging
 
-- Copy `.env.example` to `.env.staging.local` and set the appropriate values of the environment variables.
+- Copy `.env.example` to `.env.staging` and set the appropriate values of the environment variables.
 
 - Run the following command
 
@@ -84,7 +84,7 @@ npm run build --mode staging
 
 #### Production
 
-- Copy `.env.example` to `.env.production.local` and set the appropriate values of the environment variables.
+- Copy `.env.example` to `.env.production` and set the appropriate values of the environment variables.
 
 - Run the following command
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,6 @@
+## Environment Variables
+
+### Backend
+
+- `VUE_APP_BACKEND`
+  The URL of the backend.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "content-set-player",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^0.26.1",
         "core-js": "^3.21.1",
         "vue": "^3.2.31",
-        "vue-inline-svg": "^2.1.0",
         "vue-router": "^4.0.12",
         "vuex": "^4.0.2"
       },
@@ -5392,6 +5392,14 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -10164,7 +10172,6 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -20043,11 +20050,6 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
-    "node_modules/vue-inline-svg": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vue-inline-svg/-/vue-inline-svg-2.1.0.tgz",
-      "integrity": "sha512-80u/BGtjOzXp31yFahXsfvkBrHKHEHKyrkZ42MGoAbD6jHzWpMJLijsyRj66pps7IyKxZcnYkO3ijsJhr4zXsg=="
-    },
     "node_modules/vue-loader": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-17.0.0.tgz",
@@ -25340,6 +25342,14 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -29045,8 +29055,7 @@
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "dev": true
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "foreach": {
       "version": "2.0.5",
@@ -36428,11 +36437,6 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
-    },
-    "vue-inline-svg": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vue-inline-svg/-/vue-inline-svg-2.1.0.tgz",
-      "integrity": "sha512-80u/BGtjOzXp31yFahXsfvkBrHKHEHKyrkZ42MGoAbD6jHzWpMJLijsyRj66pps7IyKxZcnYkO3ijsJhr4zXsg=="
     },
     "vue-loader": {
       "version": "17.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "axios": "^0.26.1",
     "core-js": "^3.21.1",
     "vue": "^3.2.31",
     "vue-router": "^4.0.12",

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -191,9 +191,9 @@ export default defineComponent({
      *
      * handles the 4 different cases:
      * - the given option has not been selected
-     * - question is non-graded and given option is the right answer
-     * - question is non-graded and given option is the wrong answer
-     * - question is graded and the given option has been selected
+     * - question is graded and given option is the right answer
+     * - question is graded and given option is the wrong answer
+     * - question is non-graded and the given option has been selected
      * @param {Number} optionIndex - index of the option
      */
     function optionBackgroundClass(optionIndex: Number) {

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -60,7 +60,7 @@
                   :data-test="`optionSelector-${optionIndex}`"
                 />
                 <div
-                  v-html="option"
+                  v-html="option.text"
                   class="ml-2 h-full place-self-center text-base sm:text-lg"
                   :data-test="`option-${optionIndex}`"
                 ></div>
@@ -144,7 +144,7 @@ export default defineComponent({
       type: Boolean,
     },
     questionType: {
-      default: "mcq",
+      default: "single-choice",
       type: String,
     },
     /** the character limit to be used if present */
@@ -161,8 +161,8 @@ export default defineComponent({
       default: false,
       type: Boolean,
     },
-    isSurveyQuestion: {
-      default: false,
+    isGradedQuestion: {
+      default: true,
       type: Boolean,
     },
   },
@@ -170,8 +170,8 @@ export default defineComponent({
     const state = reactive({
       isImageLoading: false,
       // set containing the question types in which options are present
-      questionTypesWithOptions: new Set(["mcq", "checkbox"]),
-      surveyAnswerClass: "bg-gray-200",
+      questionTypesWithOptions: new Set(["single-choice", "multi-choice"]),
+      nonGradedAnswerClass: "bg-gray-200",
       correctOptionClass: "text-white bg-green-500",
       wrongOptionClass: "text-white bg-red-500",
       questionTextClass:
@@ -191,9 +191,9 @@ export default defineComponent({
      *
      * handles the 4 different cases:
      * - the given option has not been selected
-     * - question is non-survey and given option is the right answer
-     * - question is non-survey and given option is the wrong answer
-     * - question is survey and the given option has been selected
+     * - question is non-graded and given option is the right answer
+     * - question is non-graded and given option is the wrong answer
+     * - question is graded and the given option has been selected
      * @param {Number} optionIndex - index of the option
      */
     function optionBackgroundClass(optionIndex: Number) {
@@ -206,13 +206,13 @@ export default defineComponent({
       }
 
       if (
-        !props.isSurveyQuestion &&
+        props.isGradedQuestion &&
         props.correctAnswer.indexOf(optionIndex) != -1
       ) {
         return state.correctOptionClass;
       }
       if (props.submittedAnswer.indexOf(optionIndex) != -1) {
-        if (props.isSurveyQuestion) return state.surveyAnswerClass;
+        if (!props.isGradedQuestion) return state.nonGradedAnswerClass;
         return state.wrongOptionClass;
       }
     }
@@ -268,10 +268,12 @@ export default defineComponent({
     const isQuestionTypeSubjective = computed(
       () => props.questionType == "subjective"
     );
-    const isQuestionTypeCheckbox = computed(
-      () => props.questionType == "checkbox"
+    const isQuestionTypeMultiChoice = computed(
+      () => props.questionType == "multi-choice"
     );
-    const isQuestionTypeMCQ = computed(() => props.questionType == "mcq");
+    const isQuestionTypeSingleChoice = computed(
+      () => props.questionType == "single-choice"
+    );
 
     // styling class to decide orientation of image + options
     // depending on portrait/landscape orientation
@@ -287,8 +289,8 @@ export default defineComponent({
 
     const optionInputType = computed(() => {
       if (!areOptionsVisible.value) return null;
-      if (isQuestionTypeMCQ.value) return "radio";
-      if (isQuestionTypeCheckbox.value) return "checkbox";
+      if (isQuestionTypeSingleChoice.value) return "radio";
+      if (isQuestionTypeMultiChoice.value) return "checkbox";
       return null;
     });
 
@@ -376,8 +378,8 @@ export default defineComponent({
       isQuestionImagePresent,
       areOptionsVisible,
       isQuestionTypeSubjective,
-      isQuestionTypeCheckbox,
-      isQuestionTypeMCQ,
+      isQuestionTypeMultiChoice,
+      isQuestionTypeSingleChoice,
       orientationClass,
       optionInputType,
       answerContainerClass,

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -8,7 +8,7 @@
       :options="currentQuestion.options"
       :correctAnswer="questionCorrectAnswer"
       :questionType="questionType"
-      :isSurveyQuestion="isSurveyQuestion"
+      :isGradedQuestion="isGradedQuestion"
       :maxCharLimit="currentQuestion.max_char_limit"
       :isPortrait="isPortrait"
       :imageData="currentQuestion?.image"
@@ -104,13 +104,13 @@ export default defineComponent({
      * triggered upon selecting an option
      */
     function questionOptionSelected(optionIndex: number) {
-      if (isQuestionTypeMCQ.value) {
+      if (isQuestionTypeSingleChoice.value) {
         // for MCQ, simply set the option as the current response
         state.draftResponses[props.currentQuestionIndex] = [optionIndex];
         return;
       }
 
-      if (isQuestionTypeCheckbox.value) {
+      if (isQuestionTypeMultiChoice.value) {
         if (state.draftResponses[props.currentQuestionIndex] == null) {
           state.draftResponses[props.currentQuestionIndex] = [];
         }
@@ -171,12 +171,14 @@ export default defineComponent({
       () => currentQuestion.value?.correct_answer
     );
 
-    const isSurveyQuestion = computed(() => currentQuestion.value.survey);
+    const isGradedQuestion = computed(() => currentQuestion.value.graded);
 
-    const isQuestionTypeCheckbox = computed(
-      () => questionType.value == "checkbox"
+    const isQuestionTypeMultiChoice = computed(
+      () => questionType.value == "multi-choice"
     );
-    const isQuestionTypeMCQ = computed(() => questionType.value == "mcq");
+    const isQuestionTypeSingleChoice = computed(
+      () => questionType.value == "single-choice"
+    );
     const isQuestionTypeSubjective = computed(
       () => questionType.value == "subjective"
     );
@@ -191,7 +193,7 @@ export default defineComponent({
 
     const isAnswerSubmitted = computed(() => {
       if (currentQuestionResponseAnswer.value == null) return false;
-      if (isQuestionTypeMCQ.value || isQuestionTypeCheckbox.value) {
+      if (isQuestionTypeSingleChoice.value || isQuestionTypeMultiChoice.value) {
         return currentQuestionResponseAnswer.value.length > 0;
       }
       return true;
@@ -226,7 +228,7 @@ export default defineComponent({
       currentQuestion,
       questionType,
       questionCorrectAnswer,
-      isSurveyQuestion,
+      isGradedQuestion,
       currentQuestionResponseAnswer,
       isAnswerSubmitted,
       isAttemptValid,

--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -31,8 +31,8 @@
               :iconClass="metadataIconClass"
             ></BaseIcon>
 
-            <div class="flex items-center" data-test="classNumber">
-              <p :class="metadataTitleClass">Class {{ classNumber }}</p>
+            <div class="flex items-center" data-test="grade">
+              <p :class="metadataTitleClass">Class {{ grade }}</p>
             </div>
           </div>
         </div>
@@ -92,8 +92,8 @@ export default defineComponent({
       type: Number,
       required: true,
     },
-    classNumber: {
-      type: Number,
+    grade: {
+      type: String,
       required: true,
     },
   },

--- a/src/components/UI/Icons/BaseIcon.vue
+++ b/src/components/UI/Icons/BaseIcon.vue
@@ -9,6 +9,7 @@
     <Wrong v-if="name == 'wrong'"></Wrong>
     <SpinnerSolid v-if="name == 'spinner-solid'"></SpinnerSolid>
     <RightArrow v-if="name == 'right-arrow'"></RightArrow>
+    <Warning v-if="name == 'warning'"></Warning>
   </div>
 </template>
 
@@ -22,6 +23,7 @@ import Correct from "./Correct.vue";
 import Wrong from "./Wrong.vue";
 import SpinnerSolid from "./SpinnerSolid.vue";
 import RightArrow from "./RightArrow.vue";
+import Warning from "./Warning.vue";
 
 export default {
   name: "BaseIcon",
@@ -35,6 +37,7 @@ export default {
     Wrong,
     SpinnerSolid,
     RightArrow,
+    Warning,
   },
   props: {
     name: {

--- a/src/components/UI/Icons/Warning.vue
+++ b/src/components/UI/Icons/Warning.vue
@@ -1,0 +1,21 @@
+<template>
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    data-icon="exclamation-circle"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 512 512"
+  >
+    <path
+      fill="currentColor"
+      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+    ></path>
+  </svg>
+</template>
+
+<script>
+export default {
+  name: "Warning",
+};
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,8 +2,9 @@ import { createRouter, createWebHistory } from "vue-router";
 
 const routes = [
   {
-    path: "/",
+    path: "/:quizId",
     name: "Player",
+    props: true,
     // route level code-splitting
     // this generates a separate chunk (about.[hash].js) for this route
     // which is lazy-loaded when the route is visited.

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,9 +5,7 @@ const routes = [
     path: "/:quizId",
     name: "Player",
     props: true,
-    // route level code-splitting
-    // this generates a separate chunk (about.[hash].js) for this route
-    // which is lazy-loaded when the route is visited.
+    // lazy-loading: https://router.vuejs.org/guide/advanced/lazy-loading.html
     component: () =>
       import(/* webpackChunkName: "about" */ "@/views/Player.vue"),
   },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,6 +10,20 @@ const routes = [
     component: () =>
       import(/* webpackChunkName: "about" */ "@/views/Player.vue"),
   },
+  {
+    path: "/404-not-found",
+    name: "404",
+    component: () =>
+      import(/* webpackChunkName: "error" */ "@/views/Error.vue"),
+    props: { type: "404" },
+  },
+  {
+    // refer to: https://stackoverflow.com/a/64186073/7870587
+    path: "/:pathMatch(.*)*",
+    redirect: {
+      name: "404",
+    },
+  },
 ];
 
 const router = createRouter({

--- a/src/services/API/Endpoints.ts
+++ b/src/services/API/Endpoints.ts
@@ -1,0 +1,1 @@
+export const quizEndpoint = "/quiz/";

--- a/src/services/API/ErrorHandling.ts
+++ b/src/services/API/ErrorHandling.ts
@@ -1,0 +1,14 @@
+import router from "@/router";
+import { AxiosError } from "axios";
+
+export default {
+  handleAPIErrors(error: AxiosError) {
+    if (
+      error != undefined &&
+      "response" in error &&
+      error.response != undefined
+    ) {
+      if (error.response.status === 404) router.replace({ name: "404" });
+    }
+  },
+};

--- a/src/services/API/ErrorHandling.ts
+++ b/src/services/API/ErrorHandling.ts
@@ -3,11 +3,7 @@ import { AxiosError } from "axios";
 
 export default {
   handleAPIErrors(error: AxiosError) {
-    if (
-      error != undefined &&
-      "response" in error &&
-      error.response != undefined
-    ) {
+    if (error?.response != undefined) {
       if (error.response.status === 404) router.replace({ name: "404" });
     }
   },

--- a/src/services/API/Quiz.ts
+++ b/src/services/API/Quiz.ts
@@ -6,8 +6,8 @@ import { QuizResponse } from "../../types";
 export default {
   /**
    * returns the details for a quiz
-   * @param {Number} quizId - uuid of the quiz to be fetched
-   * @returns {Object} data corresponding to the quiz
+   * @param {string} quizId - uuid of the quiz to be fetched
+   * @returns {Promise<QuizResponse>} data corresponding to the quiz
    */
   async getQuiz(quizId: string): Promise<QuizResponse> {
     const response = await apiClient().get(quizEndpoint + quizId);

--- a/src/services/API/Quiz.ts
+++ b/src/services/API/Quiz.ts
@@ -1,0 +1,16 @@
+import { apiClient } from "./RootClient";
+import { quizEndpoint } from "./Endpoints";
+import { AxiosResponse } from "axios";
+import { QuizResponse } from "../../types";
+
+export default {
+  /**
+   * returns the details for a quiz
+   * @param {Number} quizId - uuid of the quiz to be fetched
+   * @returns {Object} data corresponding to the quiz
+   */
+  async getQuiz(quizId: string): Promise<QuizResponse> {
+    const response = await apiClient().get(quizEndpoint + quizId);
+    return response.data;
+  },
+};

--- a/src/services/API/RootClient.ts
+++ b/src/services/API/RootClient.ts
@@ -1,0 +1,32 @@
+import axios, { AxiosRequestConfig, AxiosError, AxiosInstance } from "axios";
+import ErrorHandling from "./ErrorHandling";
+
+// const headers = {
+//   Accept: "application/json",
+//   "Content-Type": "application/json",
+// };
+
+// backend API client
+const client = axios.create({
+  baseURL: process.env.VUE_APP_BACKEND,
+  withCredentials: false,
+  // headers,
+});
+
+// handle errors in responses for API requests
+client.interceptors.response.use(
+  (config: AxiosRequestConfig): AxiosRequestConfig => {
+    return config;
+  },
+  async (error: AxiosError): Promise<AxiosError> => {
+    // logging the error
+    console.log(error);
+
+    ErrorHandling.handleAPIErrors(error);
+    return Promise.reject(error);
+  }
+);
+
+export function apiClient(): AxiosInstance {
+  return client;
+}

--- a/src/services/API/RootClient.ts
+++ b/src/services/API/RootClient.ts
@@ -1,16 +1,10 @@
 import axios, { AxiosRequestConfig, AxiosError, AxiosInstance } from "axios";
 import ErrorHandling from "./ErrorHandling";
 
-// const headers = {
-//   Accept: "application/json",
-//   "Content-Type": "application/json",
-// };
-
 // backend API client
 const client = axios.create({
   baseURL: process.env.VUE_APP_BACKEND,
   withCredentials: false,
-  // headers,
 });
 
 // handle errors in responses for API requests

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,10 @@
 // contains all the custom types that we want to use
 
-type questionWithOptions = "mcq" | "checkbox";
+type questionWithOptions = "single-choice" | "multi-choice";
 type questionType = questionWithOptions | "subjective";
-
-export interface Question {
-  type: questionType;
-  text: string;
-  options: string[];
-  correct_answer: number | number[] | null;
-  image: string | null;
-  max_char_limit: number | null;
-  survey: boolean;
-}
+type language = "en" | "hi";
+type quizType = "assessment" | "JEE";
+type quizNavigationMode = "linear" | "non-linear";
 
 export interface IconButtonTitleConfig {
   value: string;
@@ -35,4 +28,76 @@ export type DraftResponse = number[] | string | null;
 
 export interface SubmittedResponse {
   answer: number[] | string | null;
+}
+
+export interface QuizMetadata {
+  quiz_type: quizType;
+  grade: string;
+  subject: string;
+  chapter?: string;
+  topic?: string;
+}
+
+interface QuestionMetadata {
+  grade: string;
+  subject: string;
+  chapter: string;
+  topic: string;
+  competency: string[];
+  difficulty: string;
+}
+
+interface TimeLimit {
+  min: number;
+  max: number;
+}
+
+interface Image {
+  url: string;
+  alt_text: string;
+}
+
+interface MarkingScheme {
+  correct: number;
+  wrong: number;
+  skipped: number;
+}
+
+interface Option {
+  text: string;
+  image: Image | null;
+}
+
+export interface Question {
+  type: questionType;
+  text: string;
+  options: Option[] | null;
+  correct_answer: number[] | null;
+  image: Image | null;
+  max_char_limit: number | null;
+  graded: boolean;
+  instructions: string | null;
+  markingScheme: MarkingScheme | null;
+  solution: string[] | null;
+  _id: string;
+  metadata: QuestionMetadata | null;
+}
+
+interface QuestionSet {
+  _id: string;
+  questions: Question[];
+}
+
+export interface QuizResponse {
+  instructions: string;
+  _id: string;
+  language: language;
+  maxMarks: number;
+  metadata: QuizMetadata;
+  navigation_mode: quizNavigationMode;
+  numAttemptsAllowed: number;
+  numGradedQuestions: number;
+  shuffle: boolean;
+  timeLimit: TimeLimit | null;
+  question_sets: QuestionSet[];
 }

--- a/src/views/Error.vue
+++ b/src/views/Error.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="flex flex-col space-y-8 items-center">
+    <!-- 404 -->
+    <div
+      v-if="isError404"
+      class="w-full mt-16 flex flex-col space-y-4 items-center"
+    >
+      <BaseIcon
+        name="warning"
+        iconClass="w-12 h-12 text-yellow-600 fill-current"
+      />
+      <p class="text-2xl align-middle">Page Not Found</p>
+      <p class="text-lg text-gray-500 text-center w-10/12 sm:w-1/2">
+        We are unable to find what you are looking for
+      </p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from "vue";
+import BaseIcon from "../components/UI/Icons/BaseIcon.vue";
+
+export default defineComponent({
+  props: {
+    type: {
+      type: String,
+      default: "404",
+    },
+  },
+  components: {
+    BaseIcon,
+  },
+  setup(props) {
+    /** whether the error type is 404 */
+    const isError404 = computed(() => {
+      return props.type === "404";
+    });
+    return {
+      isError404,
+    };
+  },
+});
+</script>

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -1,31 +1,34 @@
 <template>
   <div class="h-screen">
-    <Splash
-      v-if="isSplashShown"
-      :title="title"
-      :subject="metadata.subject"
-      :classNumber="metadata.class"
-      :numQuestions="questions.length"
-      :quizType="metadata.quizType"
-      @start="startQuiz"
-      data-test="splash"
-    ></Splash>
+    <div v-if="isQuizLoaded" class="h-full">
+      <Splash
+        v-if="isSplashShown"
+        :title="title"
+        :subject="metadata.subject"
+        :grade="metadata.grade"
+        :numQuestions="questions.length"
+        :quizType="metadata.quiz_type"
+        @start="startQuiz"
+        data-test="splash"
+      ></Splash>
 
-    <QuestionModal
-      :questions="questions"
-      v-model:currentQuestionIndex="currentQuestionIndex"
-      v-model:responses="responses"
-      v-if="isQuestionShown"
-      data-test="modal"
-    ></QuestionModal>
+      <QuestionModal
+        :questions="questions"
+        v-model:currentQuestionIndex="currentQuestionIndex"
+        v-model:responses="responses"
+        v-if="isQuestionShown"
+        data-test="modal"
+      ></QuestionModal>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import QuestionModal from "../components/Questions/QuestionModal.vue";
 import Splash from "../components/Splash.vue";
+import QuizAPIService from "../services/API/Quiz";
 import { defineComponent, reactive, toRefs, computed } from "vue";
-import { Question, SubmittedResponse } from "../types";
+import { Question, SubmittedResponse, QuizMetadata } from "../types";
 
 export default defineComponent({
   name: "Player",
@@ -37,52 +40,8 @@ export default defineComponent({
     const state = reactive({
       currentQuestionIndex: -1 as number,
       title: "Geometry Quiz" as string,
-      metadata: {
-        quizType: "CBSE",
-        subject: "Maths",
-        class: 8,
-      },
-      questions: [
-        {
-          type: "mcq",
-          text: "abcd",
-          options: ["option 1", "option 2"],
-          correct_answer: [0],
-          image: null,
-          survey: false,
-          max_char_limit: null,
-        },
-        {
-          type: "subjective",
-          text: "yolo",
-          options: ["", ""],
-          correct_answer: null,
-          image: null,
-          survey: false,
-          max_char_limit: 100,
-        },
-        {
-          type: "checkbox",
-          text: "efgh",
-          options: ["option 1", "option 2", "op3", "option 4"],
-          correct_answer: [2, 3],
-          image: null,
-          survey: false,
-          max_char_limit: null,
-        },
-        {
-          type: "checkbox",
-          text: "ijkl",
-          options: ["", "", ""],
-          correct_answer: [0, 1],
-          image: {
-            url: "https://plio-prod-assets.s3.ap-south-1.amazonaws.com/images/afbxudrmbl.png",
-            alt_text: "some image",
-          },
-          survey: true,
-          max_char_limit: null,
-        },
-      ] as Question[],
+      metadata: {} as QuizMetadata,
+      questions: [] as Question[],
       responses: [] as SubmittedResponse[], // holds the responses to each item submitted by the viewer
     });
     const isSplashShown = computed(() => state.currentQuestionIndex == -1);
@@ -92,22 +51,37 @@ export default defineComponent({
         state.currentQuestionIndex < state.questions.length
       );
     });
+    const isQuizLoaded = computed(() => state.questions.length > 0);
 
     function startQuiz() {
       state.currentQuestionIndex = 0;
     }
 
-    state.questions.forEach((_, itemIndex) => {
-      state.responses.push({
-        answer: null,
+    async function getQuiz() {
+      const quizDetails = await QuizAPIService.getQuiz(
+        "62540adb0f748c8e206c1612"
+      );
+      // since we know that there is going to be only one
+      // question set for now
+      const questionSet = quizDetails.question_sets[0];
+      state.questions = questionSet.questions;
+      state.metadata = quizDetails.metadata;
+
+      state.questions.forEach((_) => {
+        state.responses.push({
+          answer: null,
+        });
       });
-    });
+    }
+
+    getQuiz();
 
     return {
       ...toRefs(state),
       isQuestionShown,
       isSplashShown,
       startQuiz,
+      isQuizLoaded,
     };
   },
 });

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -36,7 +36,13 @@ export default defineComponent({
     Splash,
     QuestionModal,
   },
-  setup() {
+  props: {
+    quizId: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
     const state = reactive({
       currentQuestionIndex: -1 as number,
       title: "Geometry Quiz" as string,
@@ -58,15 +64,14 @@ export default defineComponent({
     }
 
     async function getQuiz() {
-      const quizDetails = await QuizAPIService.getQuiz(
-        "62540adb0f748c8e206c1612"
-      );
+      const quizDetails = await QuizAPIService.getQuiz(props.quizId);
       // since we know that there is going to be only one
       // question set for now
       const questionSet = quizDetails.question_sets[0];
       state.questions = questionSet.questions;
       state.metadata = quizDetails.metadata;
 
+      // prepare responses
       state.questions.forEach((_) => {
         state.responses.push({
           answer: null,

--- a/tests/e2e/fixtures/quiz.json
+++ b/tests/e2e/fixtures/quiz.json
@@ -1,0 +1,88 @@
+{
+  "_id": "62540adb0f748c8e206c1612",
+  "question_sets": [
+    {
+      "_id": "62540adb0f748c8e206c1613",
+      "questions": [
+        {
+          "_id": "62540adb0f748c8e206c1614",
+          "text": "Which grade are you in?",
+          "type": "single-choice",
+          "instructions": null,
+          "image": null,
+          "options": [
+            { "text": "Option 1", "image": null },
+            { "text": "Option 2", "image": null },
+            { "text": "Option 3", "image": null }
+          ],
+          "max_char_limit": null,
+          "correct_answer": null,
+          "graded": false,
+          "marking_scheme": null,
+          "solution": [],
+          "metadata": null
+        },
+        {
+          "_id": "62540adb0f748c8e206c1615",
+          "text": "Which grade are you in?",
+          "type": "multi-choice",
+          "instructions": null,
+          "image": {
+            "url": "https://plio-prod-assets.s3.ap-south-1.amazonaws.com/images/afbxudrmbl.png",
+            "alt_text": "Image"
+          },
+          "options": [
+            { "text": "Option 1", "image": null },
+            {
+              "text": "Option 2",
+              "image": {
+                "url": "https://plio-prod-assets.s3.ap-south-1.amazonaws.com/images/afbxudrmbl.png",
+                "alt_text": null
+              }
+            },
+            { "text": "Option 3", "image": null }
+          ],
+          "max_char_limit": null,
+          "correct_answer": [0, 2],
+          "graded": true,
+          "marking_scheme": null,
+          "solution": [],
+          "metadata": null
+        },
+        {
+          "_id": "62540adb0f748c8e206c1616",
+          "text": "Which subject are you studying?",
+          "type": "multi-choice",
+          "instructions": null,
+          "image": null,
+          "options": [
+            { "text": "Option 1", "image": null },
+            { "text": "Option 2", "image": null },
+            { "text": "Option 3", "image": null }
+          ],
+          "max_char_limit": null,
+          "correct_answer": null,
+          "graded": false,
+          "marking_scheme": null,
+          "solution": [],
+          "metadata": null
+        }
+      ]
+    }
+  ],
+  "max_marks": 10,
+  "num_graded_questions": 1,
+  "shuffle": false,
+  "num_attempts_allowed": 1,
+  "time_limit": null,
+  "navigation_mode": "linear",
+  "instructions": null,
+  "language": "en",
+  "metadata": {
+    "quiz_type": "JEE",
+    "grade": "8",
+    "subject": "Maths",
+    "chapter": null,
+    "topic": null
+  }
+}

--- a/tests/e2e/specs/renders-player.js
+++ b/tests/e2e/specs/renders-player.js
@@ -43,19 +43,6 @@ describe("Player", () => {
         .trigger("click");
 
       // question 2
-      // cy.get('[data-test="modal"]')
-      //   .get('[data-test="subjectiveAnswer"]')
-      //   .get('[data-test="input"]')
-      //   .type("abcd");
-      // cy.get('[data-test="modal"]')
-      //   .get('[data-test="submitButton"]')
-      //   .trigger("click");
-      // // continue button
-      // cy.get('[data-test="modal"]')
-      //   .get('[data-test="submitButton"]')
-      //   .trigger("click");
-
-      // question 3
       cy.get('[data-test="modal"]')
         .get('[data-test="optionSelector-0"]')
         .trigger("click");
@@ -67,7 +54,7 @@ describe("Player", () => {
         .get('[data-test="submitButton"]')
         .trigger("click");
 
-      // question 4
+      // question 3
       cy.get('[data-test="modal"]')
         .get('[data-test="optionSelector-0"]')
         .trigger("click");

--- a/tests/e2e/specs/renders-player.js
+++ b/tests/e2e/specs/renders-player.js
@@ -1,74 +1,86 @@
 // https://docs.cypress.io/api/introduction/api.html
 
 describe("Player", () => {
-  beforeEach(() => {
+  it("shows 404 error page when quiz ID not provided", () => {
     cy.visit("/");
+    // we should be redirected to 404 error page
+    cy.url().should("include", "/404-not-found");
   });
-  it("shows splash screen", () => {
-    cy.get('[data-test="splash"]').should("exist");
-    cy.get('[data-test="modal"]').should("not.exist");
-    cy.get('[data-test="startQuiz"]').should("exist");
-  });
+  describe("Quiz ID provided", () => {
+    beforeEach(() => {
+      // stub the response to /quiz/{quizId}
+      cy.intercept("GET", "/quiz/*", {
+        fixture: "quiz.json",
+      });
 
-  it("shows modal upon clicking start button on splash screen", () => {
-    cy.get('[data-test="startQuiz"]').trigger("click");
-    cy.get('[data-test="splash"]').should("not.exist");
-    cy.get('[data-test="modal"]').should("exist");
-  });
+      cy.visit("/abcd");
+    });
+    it("shows splash screen", () => {
+      cy.get('[data-test="splash"]').should("exist");
+      cy.get('[data-test="modal"]').should("not.exist");
+      cy.get('[data-test="startQuiz"]').should("exist");
+    });
 
-  it("neither splash screen nor modal shown when all questions are answered", () => {
-    cy.get('[data-test="startQuiz"]').trigger("click");
+    it("shows modal upon clicking start button on splash screen", () => {
+      cy.get('[data-test="startQuiz"]').trigger("click");
+      cy.get('[data-test="splash"]').should("not.exist");
+      cy.get('[data-test="modal"]').should("exist");
+    });
 
-    // question 1
-    cy.get('[data-test="modal"]')
-      .get('[data-test="optionSelector-0"]')
-      .trigger("click");
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
-    // continue button
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
+    it("neither splash screen nor modal shown when all questions are answered", () => {
+      cy.get('[data-test="startQuiz"]').trigger("click");
 
-    // question 2
-    cy.get('[data-test="modal"]')
-      .get('[data-test="subjectiveAnswer"]')
-      .get('[data-test="input"]')
-      .type("abcd");
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
-    // continue button
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
+      // question 1
+      cy.get('[data-test="modal"]')
+        .get('[data-test="optionSelector-0"]')
+        .trigger("click");
+      cy.get('[data-test="modal"]')
+        .get('[data-test="submitButton"]')
+        .trigger("click");
+      // continue button
+      cy.get('[data-test="modal"]')
+        .get('[data-test="submitButton"]')
+        .trigger("click");
 
-    // question 3
-    cy.get('[data-test="modal"]')
-      .get('[data-test="optionSelector-0"]')
-      .trigger("click");
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
-    // continue button
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
+      // question 2
+      // cy.get('[data-test="modal"]')
+      //   .get('[data-test="subjectiveAnswer"]')
+      //   .get('[data-test="input"]')
+      //   .type("abcd");
+      // cy.get('[data-test="modal"]')
+      //   .get('[data-test="submitButton"]')
+      //   .trigger("click");
+      // // continue button
+      // cy.get('[data-test="modal"]')
+      //   .get('[data-test="submitButton"]')
+      //   .trigger("click");
 
-    // question 4
-    cy.get('[data-test="modal"]')
-      .get('[data-test="optionSelector-0"]')
-      .trigger("click");
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
-    // continue button
-    cy.get('[data-test="modal"]')
-      .get('[data-test="submitButton"]')
-      .trigger("click");
+      // question 3
+      cy.get('[data-test="modal"]')
+        .get('[data-test="optionSelector-0"]')
+        .trigger("click");
+      cy.get('[data-test="modal"]')
+        .get('[data-test="submitButton"]')
+        .trigger("click");
+      // continue button
+      cy.get('[data-test="modal"]')
+        .get('[data-test="submitButton"]')
+        .trigger("click");
 
-    cy.get('[data-test="splash"]').should("not.exist");
-    cy.get('[data-test="modal"]').should("not.exist");
+      // question 4
+      cy.get('[data-test="modal"]')
+        .get('[data-test="optionSelector-0"]')
+        .trigger("click");
+      cy.get('[data-test="modal"]')
+        .get('[data-test="submitButton"]')
+        .trigger("click");
+      // continue button
+      cy.get('[data-test="modal"]')
+        .get('[data-test="submitButton"]')
+        .trigger("click");
+
+      cy.get('[data-test="splash"]').should("not.exist");
+      cy.get('[data-test="modal"]').should("not.exist");
+    });
   });
 });

--- a/tests/unit/components/Questions/Body.spec.ts
+++ b/tests/unit/components/Questions/Body.spec.ts
@@ -22,7 +22,7 @@ describe("Body.vue", () => {
 
     it("starts loading image if imageData is passed", async () => {
       await wrapper.setProps({
-        questionType: "mcq",
+        questionType: "single-choice",
         imageData: {
           url: "mock",
           alt_text: "mock",
@@ -33,7 +33,7 @@ describe("Body.vue", () => {
     });
   });
 
-  describe("mcq questions", () => {
+  describe("single-choice questions", () => {
     const options = ["a", ""];
     const wrapper = mount(Body, {
       props: {
@@ -86,12 +86,12 @@ describe("Body.vue", () => {
       ).toContain("bg-red-500");
     });
 
-    it("highlights options as gray for survey mode answers", async () => {
+    it("highlights options as gray for non-graded questions", async () => {
       const submittedAnswer = [0];
       await wrapper.setProps({
         submittedAnswer: submittedAnswer,
         isAnswerSubmitted: true,
-        isSurveyQuestion: true,
+        isGradedQuestion: false,
       });
 
       expect(
@@ -100,12 +100,12 @@ describe("Body.vue", () => {
     });
   });
 
-  describe("checkbox", () => {
+  describe("multi-choice", () => {
     const options = ["a", "b", "c"];
     const wrapper = mount(Body, {
       props: {
         options: options,
-        questionType: "checkbox",
+        questionType: "multi-choice",
       },
     });
 
@@ -129,12 +129,12 @@ describe("Body.vue", () => {
       expect(wrapper.vm.isOptionMarked(2)).toBeTruthy();
     });
 
-    it("option text selected correctly", () => {
+    it("selects option text correctly", () => {
       wrapper.find('[data-test="option-0"]').trigger("click");
       expect(wrapper.emitted()).toHaveProperty("option-selected");
     });
 
-    it("option checkbox selected correctly", () => {
+    it("selects option checkbox correctly", () => {
       wrapper.find('[data-test="optionSelector-0"]').trigger("click");
       expect(wrapper.emitted()).toHaveProperty("option-selected");
     });
@@ -159,12 +159,12 @@ describe("Body.vue", () => {
       ).toContain("bg-red-500");
     });
 
-    it("highlights options gray for survey mode answers", async () => {
+    it("highlights options gray for non-graded questions", async () => {
       const submittedAnswer = [1, 2];
       await wrapper.setProps({
         submittedAnswer: submittedAnswer,
         isAnswerSubmitted: true,
-        isSurveyQuestion: true,
+        isGradedQuestion: false,
       });
 
       expect(

--- a/tests/unit/components/Questions/Body.spec.ts
+++ b/tests/unit/components/Questions/Body.spec.ts
@@ -34,7 +34,14 @@ describe("Body.vue", () => {
   });
 
   describe("single-choice questions", () => {
-    const options = ["a", ""];
+    const options = [
+      {
+        text: "a",
+      },
+      {
+        text: "",
+      },
+    ];
     const wrapper = mount(Body, {
       props: {
         options: options,
@@ -45,7 +52,9 @@ describe("Body.vue", () => {
       expect(wrapper.find('[data-test="option-0"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="option-1"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="option-2"]').exists()).toBe(false);
-      expect(wrapper.find('[data-test="option-0"]').text()).toBe(options[0]);
+      expect(wrapper.find('[data-test="option-0"]').text()).toBe(
+        options[0].text
+      );
       expect(wrapper.vm.optionInputType).toBe("radio");
     });
 
@@ -101,7 +110,17 @@ describe("Body.vue", () => {
   });
 
   describe("multi-choice", () => {
-    const options = ["a", "b", "c"];
+    const options = [
+      {
+        text: "a",
+      },
+      {
+        text: "b",
+      },
+      {
+        text: "c",
+      },
+    ];
     const wrapper = mount(Body, {
       props: {
         options: options,
@@ -114,7 +133,9 @@ describe("Body.vue", () => {
       expect(wrapper.find('[data-test="option-1"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="option-2"]').exists()).toBe(true);
       expect(wrapper.find('[data-test="option-3"]').exists()).toBe(false);
-      expect(wrapper.find('[data-test="option-0"]').text()).toBe(options[0]);
+      expect(wrapper.find('[data-test="option-0"]').text()).toBe(
+        options[0].text
+      );
       expect(wrapper.vm.optionInputType).toBe("checkbox");
     });
 

--- a/tests/unit/components/Questions/QuestionModal.spec.ts
+++ b/tests/unit/components/Questions/QuestionModal.spec.ts
@@ -7,30 +7,50 @@ let clonedeep = require("lodash.clonedeep");
 describe("ItemModal.vue", () => {
   const questions = [
     {
-      type: "mcq",
+      type: "single-choice",
       text: "abcd",
-      options: ["option 1", "option 2"],
+      options: [
+        {
+          text: "option 1",
+        },
+        {
+          text: "option 2",
+        },
+      ],
       correct_answer: [0],
       image: null,
-      survey: false,
+      graded: false,
       max_char_limit: null,
     },
     {
-      type: "checkbox",
+      type: "multi-choice",
       text: "efgh",
-      options: ["option 1", "option 2", "op3", "option 4"],
+      options: [
+        {
+          text: "option 1",
+        },
+        {
+          text: "option 2",
+        },
+        {
+          text: "op3",
+        },
+        {
+          text: "option 4",
+        },
+      ],
       correct_answer: [2, 3],
       image: null,
-      survey: false,
+      graded: false,
       max_char_limit: null,
     },
     {
       type: "subjective",
       text: "yolo",
-      options: ["", ""],
+      options: null,
       correct_answer: null,
       image: null,
-      survey: false,
+      graded: false,
       max_char_limit: 100,
     },
   ] as Question[];
@@ -82,7 +102,7 @@ describe("ItemModal.vue", () => {
     });
   });
 
-  describe("mcq questions", () => {
+  describe("single-choice questions", () => {
     it("selecting option makes answer valid", async () => {
       // initially answer should be invalid
       expect(wrapper.vm.isAttemptValid).toBeFalsy();
@@ -131,7 +151,7 @@ describe("ItemModal.vue", () => {
     });
   });
 
-  describe("checkbox questions", () => {
+  describe("multi-choice questions", () => {
     const questionIndex = 1;
 
     beforeEach(() => mountWrapper({ currentQuestionIndex: questionIndex }));

--- a/tests/unit/components/Splash.spec.ts
+++ b/tests/unit/components/Splash.spec.ts
@@ -7,14 +7,14 @@ describe("Splash.vue", () => {
     const subject = "Maths";
     const quizType = "CBSE";
     const numQuestions = 3;
-    const classNumber = 8;
+    const grade = "8";
     const wrapper = mount(Splash, {
       props: {
         title: title,
         subject: subject,
         quizType: quizType,
         numQuestions: numQuestions,
-        classNumber: classNumber,
+        grade: grade,
       },
     });
     expect(wrapper.find('[data-test="title"]').text()).toBe(title);
@@ -23,9 +23,7 @@ describe("Splash.vue", () => {
     expect(wrapper.find('[data-test="numQuestions"]').text()).toContain(
       numQuestions + ""
     );
-    expect(wrapper.find('[data-test="classNumber"]').text()).toContain(
-      classNumber + ""
-    );
+    expect(wrapper.find('[data-test="grade"]').text()).toContain(grade + "");
   });
   it("emits start when start button is clicked", async () => {
     const wrapper = mount(Splash);

--- a/tests/unit/components/Splash.spec.ts
+++ b/tests/unit/components/Splash.spec.ts
@@ -2,21 +2,22 @@ import { mount } from "@vue/test-utils";
 import Splash from "@/components/Splash.vue";
 
 describe("Splash.vue", () => {
+  const title = "Geometry Quiz";
+  const subject = "Maths";
+  const quizType = "CBSE";
+  const numQuestions = 3;
+  const grade = "8";
+  const wrapper = mount(Splash, {
+    props: {
+      title: title,
+      subject: subject,
+      quizType: quizType,
+      numQuestions: numQuestions,
+      grade: grade,
+    },
+  });
+
   it("renders title correctly", () => {
-    const title = "Geometry Quiz";
-    const subject = "Maths";
-    const quizType = "CBSE";
-    const numQuestions = 3;
-    const grade = "8";
-    const wrapper = mount(Splash, {
-      props: {
-        title: title,
-        subject: subject,
-        quizType: quizType,
-        numQuestions: numQuestions,
-        grade: grade,
-      },
-    });
     expect(wrapper.find('[data-test="title"]').text()).toBe(title);
     expect(wrapper.find('[data-test="subject"]').text()).toBe(subject);
     expect(wrapper.find('[data-test="quizType"]').text()).toBe(quizType);
@@ -26,7 +27,6 @@ describe("Splash.vue", () => {
     expect(wrapper.find('[data-test="grade"]').text()).toContain(grade + "");
   });
   it("emits start when start button is clicked", async () => {
-    const wrapper = mount(Splash);
     await wrapper.find('[data-test="startQuiz"]').trigger("click");
     expect(wrapper.emitted()).toHaveProperty("start");
   });


### PR DESCRIPTION
Fixes #26 

Backend PR: https://github.com/avantifellows/quiz-backend/pull/22

Till now, you were able to view the quiz player by simply visiting `http://localhost:8080`. Now, you would have to pass in the `quizId` in the URL too. Otherwise, it will show 404. Visit: `http://localhost:8080/62540adb0f748c8e206c1612` for example. You can also create new quizzes using the backend and use their IDs.

P.S. most of the code for which the coverage is being shown as missing has actually been covered in the end-to-end test. I thought that I had fixed the issue of merging the coverage from both the unit and integration tests but it seems that hasn't happened correctly. Will resolve that in a separate PR later.

## Summary
- added axios and created an api client with baseURL of the backend
- created method to fetch the quiz details given the quiz ID
- updated the code and tests to match with the schema of the backend
- added support for environment variables in different environments: `dev` (`.env.local`), `staging` (`.env.staging.local`), `production` (`.env.production.local`).
- added an error page for the user to be redirected to if they are visiting an invalid URL
- added a bunch of new types
 
## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Test Responsiveness
  - [ ] Laptop (1200px)
  - [ ] Tablet (760px)
  - [ ] Phone (320px)
- [x] Cross-Browser Testing
  - [ ] Chrome
  - [ ] Firefox
- [ ] ~Local Language Support~
- [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [x] Check for bundle size [here](https://bundlephobia.com/) if adding a package
  - [x] Added relevant details like Labels/Projects/Milestones etc.
  - [x] If adding or removing any environment variable, update `docs/ENV.md` and `.env.example`.
- [ ] Testing
  - [ ] Wrote tests
  - [x] Tested locally
  - [ ] Tested on staging
  - [ ] Tested on an actual physical phone
  - [ ] Tested on production
- [x] Lighthouse Checks
  - [ ] ~Images have `alt` attributes~
  - [ ] ~Any `<img>` tags have `width` and `height` specified~
  - [ ] ~Any `target="_blank"` links have `rel="noopener"`~
  - [x] Only SVGs are used as images. If PNGs are used, their size has been optimised.
  - [ ] ~Any SVG buttons without text have their `aria-label` attributes set~
