### PR TITLE
Add support for assessment type quizzes

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,5 +6,6 @@
   "integrationFolder": "tests/e2e/specs",
   "screenshotsFolder": "tests/e2e/screenshots",
   "videosFolder": "tests/e2e/videos",
-  "supportFile": "tests/e2e/support/index.js"
+  "supportFile": "tests/e2e/support/index.js",
+  "ignoreTestFiles": "**/dist/*.dev.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dom-to-image": "^2.6.0",
         "vue": "^3.2.31",
         "vue-router": "^4.0.12",
+        "vue-toastification": "^2.0.0-rc.5",
         "vuex": "^4.0.2"
       },
       "devDependencies": {
@@ -20227,6 +20228,14 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "node_modules/vue-toastification": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
+      "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "peerDependencies": {
+        "vue": "^3.0.2"
+      }
+    },
     "node_modules/vuex": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
@@ -36622,6 +36631,12 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue-toastification": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
+      "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "requires": {}
     },
     "vuex": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dom-to-image": "^2.6.0",
     "vue": "^3.2.31",
     "vue-router": "^4.0.12",
+    "vue-toastification": "^2.0.0-rc.5",
     "vuex": "^4.0.2"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,10 @@
 <template>
   <div>
-  <router-view />
+    <router-view />
   </div>
 </template>
+<style>
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+}
+</style>

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -387,12 +387,14 @@ export default defineComponent({
 
     onMounted(() => {
       // Force render any math on the page when component is mounted
-      if ('MathJax' in window) (window.MathJax as any).typeset();
+      // @ts-ignore
+      if ("MathJax" in window) (window.MathJax as any).typeset();
     });
 
     onUpdated(() => {
       // Force render any math on the page when component is updated
-      if ('MathJax' in window) (window.MathJax as any).typeset();
+      // @ts-ignore
+      if ("MathJax" in window) (window.MathJax as any).typeset();
     });
 
     return {

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -54,9 +54,7 @@
                   style="box-shadow: none"
                   @click="selectOption(optionIndex)"
                   :checked="isOptionMarked(optionIndex)"
-                  :disabled="
-                    (isAnswerSubmitted && !isQuizAssessment) || hasQuizEnded
-                  "
+                  :disabled="isAnswerDisabled"
                   :data-test="`optionSelector-${optionIndex}`"
                 />
                 <div
@@ -80,9 +78,14 @@
         <Textarea
           v-model:value="subjectiveAnswer"
           class="px-2 w-full"
-          boxStyling="bp-420:h-20 sm:h-28 md:h-36 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary"
+          :boxStyling="[
+            {
+              'bg-gray-100': isAnswerSubmitted
+            },
+            'bp-420:h-20 sm:h-28 md:h-36 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary',
+          ]"
           placeholder="Enter your answer here"
-          :isDisabled="isAnswerSubmitted"
+          :isDisabled="isAnswerDisabled"
           :maxHeightLimit="250"
           @keypress="preventKeypressIfApplicable"
           data-test="subjectiveAnswer"
@@ -183,6 +186,11 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    /** whether the draft answer has been cleared but not yet submitted */
+    isDraftAnswerCleared: {
+      default: false,
+      type: Boolean,
+    },
   },
   setup(props, context) {
     const isQuizAssessment = computed(() => props.quizType == "assessment");
@@ -218,6 +226,7 @@ export default defineComponent({
     function optionBackgroundClass(optionIndex: Number) {
       if (
         !props.isAnswerSubmitted ||
+        props.isDraftAnswerCleared ||
         typeof props.correctAnswer == "string" || // check for typescript
         typeof props.submittedAnswer == "string" // check for typescript
       ) {
@@ -362,6 +371,11 @@ export default defineComponent({
 
       return "";
     });
+    const isAnswerDisabled = computed(
+      () =>
+        (props.isAnswerSubmitted && !isQuizAssessment.value) ||
+        props.hasQuizEnded
+    );
 
     state.subjectiveAnswer = defaultAnswer.value;
 
@@ -434,6 +448,7 @@ export default defineComponent({
       charactersLeft,
       maxCharLimitClass,
       isQuizAssessment,
+      isAnswerDisabled,
     };
   },
   emits: ["option-selected", "answer-entered"],

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -54,7 +54,9 @@
                   style="box-shadow: none"
                   @click="selectOption(optionIndex)"
                   :checked="isOptionMarked(optionIndex)"
-                  :disabled="isAnswerSubmitted && !isQuizAssessment"
+                  :disabled="
+                    (isAnswerSubmitted && !isQuizAssessment) || hasQuizEnded
+                  "
                   :data-test="`optionSelector-${optionIndex}`"
                 />
                 <div
@@ -176,6 +178,10 @@ export default defineComponent({
     quizType: {
       type: String as PropType<quizType>,
       default: "homework",
+    },
+    hasQuizEnded: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props, context) {

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -224,7 +224,7 @@ export default defineComponent({
         return {};
       }
 
-      if (isQuizAssessment.value) {
+      if (isQuizAssessment.value && !props.hasQuizEnded) {
         if (props.submittedAnswer.indexOf(optionIndex) != -1) {
           return state.nonGradedAnswerClass;
         }

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -197,7 +197,7 @@ export default defineComponent({
         "text-lg md:text-xl lg:text-2xl mx-4 m-2 font-bold leading-tight whitespace-pre-wrap",
       optionTextClass:
         "p-2 text-lg md:text-xl lg:text-2xl border rounded-md mx-2 whitespace-pre-wrap",
-      subjectiveAnswer: "", // holds the answer to the subjective question
+      subjectiveAnswer: "" as string | null, // holds the answer to the subjective question
     });
 
     /** stop the loading spinner when the image has been loaded **/
@@ -372,6 +372,15 @@ export default defineComponent({
         if (newValue != null) startImageLoading();
       },
       { deep: true }
+    );
+
+    watch(
+      () => props.draftAnswer,
+      (newValue) => {
+        if (typeof newValue == "string" || newValue == null) {
+          state.subjectiveAnswer = newValue;
+        }
+      }
     );
 
     watch(

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -56,7 +56,7 @@
                   style="box-shadow: none"
                   @click="selectOption(optionIndex)"
                   :checked="isOptionMarked(optionIndex)"
-                  :disabled="isAnswerSubmitted"
+                  :disabled="isAnswerSubmitted && !isQuizAssessment"
                   :data-test="`optionSelector-${optionIndex}`"
                 />
                 <div
@@ -108,7 +108,15 @@
 
 <script lang="ts">
 import Textarea from "../UI/Text/Textarea.vue";
-import { defineComponent, reactive, toRefs, computed, watch } from "vue";
+import {
+  defineComponent,
+  reactive,
+  toRefs,
+  computed,
+  watch,
+  PropType,
+} from "vue";
+import { quizType } from "../../types";
 import BaseIcon from "../UI/Icons/BaseIcon.vue";
 
 export default defineComponent({
@@ -165,8 +173,13 @@ export default defineComponent({
       default: true,
       type: Boolean,
     },
+    quizType: {
+      type: String as PropType<quizType>,
+      default: "homework",
+    },
   },
   setup(props, context) {
+    const isQuizAssessment = computed(() => props.quizType == "assessment");
     const state = reactive({
       isImageLoading: false,
       // set containing the question types in which options are present
@@ -203,6 +216,13 @@ export default defineComponent({
         typeof props.submittedAnswer == "string" // check for typescript
       ) {
         return {};
+      }
+
+      if (isQuizAssessment.value) {
+        if (props.submittedAnswer.indexOf(optionIndex) != -1) {
+          return state.nonGradedAnswerClass;
+        }
+        return;
       }
 
       if (
@@ -386,6 +406,7 @@ export default defineComponent({
       hasCharLimit,
       charactersLeft,
       maxCharLimitClass,
+      isQuizAssessment,
     };
   },
   emits: ["option-selected", "answer-entered"],

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -50,7 +50,7 @@
                 <input
                   :type="optionInputType"
                   name="option"
-                  class="place-self-center text-primary focus:ring-0"
+                  class="place-self-center text-primary focus:ring-0 disabled:cursor-not-allowed"
                   style="box-shadow: none"
                   @click="selectOption(optionIndex)"
                   :checked="isOptionMarked(optionIndex)"
@@ -78,12 +78,7 @@
         <Textarea
           v-model:value="subjectiveAnswer"
           class="px-2 w-full"
-          :boxStyling="[
-            {
-              'bg-gray-100': isAnswerSubmitted
-            },
-            'bp-420:h-20 sm:h-28 md:h-36 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary',
-          ]"
+          :boxStyling="subjectiveAnswerBoxStyling"
           placeholder="Enter your answer here"
           :isDisabled="isAnswerDisabled"
           :maxHeightLimit="250"
@@ -205,7 +200,7 @@ export default defineComponent({
         "text-lg md:text-xl lg:text-2xl mx-4 m-2 font-bold leading-tight whitespace-pre-wrap",
       optionTextClass:
         "p-2 text-lg md:text-xl lg:text-2xl border rounded-md mx-2 whitespace-pre-wrap",
-      subjectiveAnswer: "" as string | null, // holds the answer to the subjective question
+      subjectiveAnswer: null as string | null, // holds the answer to the subjective question
     });
 
     /** stop the loading spinner when the image has been loaded **/
@@ -230,7 +225,7 @@ export default defineComponent({
         typeof props.correctAnswer == "string" || // check for typescript
         typeof props.submittedAnswer == "string" // check for typescript
       ) {
-        return {};
+        return;
       }
 
       if (isQuizAssessment.value && !props.hasQuizEnded) {
@@ -377,6 +372,13 @@ export default defineComponent({
         props.hasQuizEnded
     );
 
+    const subjectiveAnswerBoxStyling = computed(() => [
+      {
+        "bg-gray-100": props.isAnswerSubmitted,
+      },
+      "bp-420:h-20 sm:h-28 md:h-36 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
+    ]);
+
     state.subjectiveAnswer = defaultAnswer.value;
 
     watch(
@@ -391,6 +393,8 @@ export default defineComponent({
     watch(
       () => props.draftAnswer,
       (newValue) => {
+        // specific to subjective questions - when the draft answer
+        // is updated, update the subjective answer too
         if (typeof newValue == "string" || newValue == null) {
           state.subjectiveAnswer = newValue;
         }
@@ -449,6 +453,7 @@ export default defineComponent({
       maxCharLimitClass,
       isQuizAssessment,
       isAnswerDisabled,
+      subjectiveAnswerBoxStyling,
     };
   },
   emits: ["option-selected", "answer-entered"],

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -99,7 +99,7 @@ export default defineComponent({
       type: Boolean,
     },
     isNextButtonShown: {
-      default: false,
+      default: true,
       type: Boolean,
     },
     hasQuizEnded: {

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -26,7 +26,7 @@
       <icon-button
         :titleConfig="clearButtonTitleConfig"
         :buttonClass="clearButtonClass"
-        :isDisabled="!isSubmitEnabled"
+        :isDisabled="!isSubmitEnabled && !isAnswerSubmitted"
         @click="clearAnswer"
         data-test="clearButton"
       ></icon-button>

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -28,7 +28,7 @@
         :buttonClass="clearButtonClass"
         :isDisabled="!isSubmitEnabled"
         @click="clearAnswer"
-        data-test="ClearButton"
+        data-test="clearButton"
       ></icon-button>
 
       <!-- save & next button -->
@@ -179,7 +179,7 @@ export default defineComponent({
     }
 
     function saveQuestionAndProceed() {
-      context.emit("submit")
+      context.emit("submit");
       context.emit("continue");
     }
 

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -7,7 +7,7 @@
     }"
   >
     <div class="place-self-start flex h-full">
-      <!-- back button -->
+      <!-- back button - assessment and homework -->
       <icon-button
         :iconConfig="previousQuestionButtonIconConfig"
         :buttonClass="assessmentNavigationButtonClass"
@@ -25,7 +25,7 @@
       v-if="isQuizAssessment && !hasQuizEnded"
       class="flex space-x-1 sm:space-x-4"
     >
-      <!-- clear button -->
+      <!-- clear button - assessment -->
       <icon-button
         :titleConfig="clearButtonTitleConfig"
         :buttonClass="clearButtonClass"
@@ -34,7 +34,7 @@
         data-test="clearButton"
       ></icon-button>
 
-      <!-- save & next button -->
+      <!-- save & next button - assessment -->
       <icon-button
         :titleConfig="saveAndNextButtonTitleConfig"
         :buttonClass="saveAndNextButtonClass"
@@ -45,7 +45,7 @@
     </div>
 
     <div class="place-self-end flex h-full">
-      <!-- submit/continue button -->
+      <!-- submit/continue button - homework-->
       <icon-button
         v-if="!isQuizAssessment"
         :titleConfig="submitButtonTitleConfig"
@@ -54,7 +54,7 @@
         @click="submitQuestion"
         data-test="submitButton"
       ></icon-button>
-      <!-- forward button -->
+      <!-- forward button - assessment -->
       <icon-button
         v-if="isQuizAssessment && isNextButtonShown"
         :iconConfig="nextQuestionButtonIconConfig"

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -21,7 +21,10 @@
       ></icon-button>
     </div>
 
-    <div v-if="isQuizAssessment" class="flex space-x-1 sm:space-x-4">
+    <div
+      v-if="isQuizAssessment && !hasQuizEnded"
+      class="flex space-x-1 sm:space-x-4"
+    >
       <!-- clear button -->
       <icon-button
         :titleConfig="clearButtonTitleConfig"
@@ -94,6 +97,10 @@ export default defineComponent({
     isPreviousButtonShown: {
       default: false,
       type: Boolean,
+    },
+    hasQuizEnded: {
+      type: Boolean,
+      default: false,
     },
     quizType: {
       type: String as PropType<quizType>,

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -178,6 +178,11 @@ export default defineComponent({
       context.emit("continue");
     }
 
+    function saveQuestionAndProceed() {
+      context.emit("submit")
+      context.emit("continue");
+    }
+
     const submitButtonTitleConfig = computed(() => {
       return {
         value: props.isAnswerSubmitted ? "Continue" : "Submit",
@@ -208,6 +213,7 @@ export default defineComponent({
       goToPreviousQuestion,
       goToNextQuestion,
       clearAnswer,
+      saveQuestionAndProceed,
       submitButtonTitleConfig,
       submitButtonClass,
       isQuizAssessment,

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -36,8 +36,8 @@
 
       <!-- save & next button -->
       <icon-button
-        :titleConfig="saveNextButtonTitleConfig"
-        :buttonClass="saveNextButtonClass"
+        :titleConfig="saveAndNextButtonTitleConfig"
+        :buttonClass="saveAndNextButtonClass"
         :isDisabled="!isAnswerSubmitted && !isSubmitEnabled"
         @click="saveQuestionAndProceed"
         data-test="saveAndNextButton"
@@ -56,7 +56,7 @@
       ></icon-button>
       <!-- forward button -->
       <icon-button
-        v-if="isQuizAssessment"
+        v-if="isQuizAssessment && isNextButtonShown"
         :iconConfig="nextQuestionButtonIconConfig"
         :buttonClass="assessmentNavigationButtonClass"
         ariaLabel="Next Question"
@@ -98,6 +98,10 @@ export default defineComponent({
       default: false,
       type: Boolean,
     },
+    isNextButtonShown: {
+      default: false,
+      type: Boolean,
+    },
     hasQuizEnded: {
       type: Boolean,
       default: false,
@@ -130,7 +134,7 @@ export default defineComponent({
         "p-2 bp-500:p-4 shadow-xl",
       ],
       assessmentTextButtonClass:
-        "p-2 px-4 bp-500:p-4 bp-500:px-6 rounded-lg sm:rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
+        "p-2 px-4 bp-500:p-4 bp-500:px-6 rounded-lg sm:rounded-2xl shadow-xl disabled:opacity-50 disabled:cursor-not-allowed",
     });
 
     const previousQuestionButtonIconConfig = ref({
@@ -153,7 +157,7 @@ export default defineComponent({
       "bg-white hover:bg-gray-50",
     ]);
 
-    const saveNextButtonClass = ref([
+    const saveAndNextButtonClass = ref([
       state.assessmentTextButtonClass,
       "bg-white hover:bg-gray-50",
     ]);
@@ -163,7 +167,7 @@ export default defineComponent({
       class: [state.assessmentTextButtonTitleClass, "text-gray-600"],
     } as IconButtonTitleConfig);
 
-    const saveNextButtonTitleConfig = ref({
+    const saveAndNextButtonTitleConfig = ref({
       value: "Save & Next",
       class: [state.assessmentTextButtonTitleClass, "text-emerald-500"],
     } as IconButtonTitleConfig);
@@ -205,7 +209,7 @@ export default defineComponent({
         "bg-primary hover:bg-primary-hover ring-primary":
           props.isAnswerSubmitted,
       },
-      "p-4 px-8 bp-500:p-6 bp-500:px-12 rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
+      "p-4 px-8 bp-500:p-6 bp-500:px-12 rounded-2xl shadow-xl disabled:opacity-50 disabled:cursor-not-allowed",
     ]);
 
     return {
@@ -213,9 +217,9 @@ export default defineComponent({
       previousQuestionButtonIconConfig,
       nextQuestionButtonIconConfig,
       clearButtonClass,
-      saveNextButtonClass,
+      saveAndNextButtonClass,
       clearButtonTitleConfig,
-      saveNextButtonTitleConfig,
+      saveAndNextButtonTitleConfig,
       submitQuestion,
       goToPreviousQuestion,
       goToNextQuestion,

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -1,27 +1,64 @@
 <template>
   <div
-    class="flex w-full bg-white p-6 bp-500:p-8 md:p-10 lg:p-12 justify-between"
+    class="flex w-full p-4 lg:p-6 justify-between"
+    :class="{
+      'bg-white': !isQuizAssessment,
+      'bg-gray-200': isQuizAssessment,
+    }"
   >
     <div class="place-self-start flex h-full">
       <!-- back button -->
       <icon-button
         :iconConfig="previousQuestionButtonIconConfig"
-        buttonClass="bg-yellow-500 hover:bg-yellow-600 ring-yellow-500 p-2 px-6 bp-500:p-4 bp-500:px-8 rounded-2xl shadow-xl"
+        :buttonClass="assessmentNavigationButtonClass"
+        :class="{
+          hidden: !isPreviousButtonShown && !isQuizAssessment,
+          invisible: !isPreviousButtonShown && isQuizAssessment,
+        }"
         ariaLabel="Previous Question"
-        v-if="isPreviousButtonShown"
-        @click="gotToPreviousQuestion"
+        @click="goToPreviousQuestion"
         data-test="previousQuestionButton"
       ></icon-button>
     </div>
 
-    <div class="place-self-end">
+    <div v-if="isQuizAssessment" class="flex space-x-4">
+      <!-- clear button -->
+      <icon-button
+        :titleConfig="clearButtonTitleConfig"
+        :buttonClass="clearButtonClass"
+        :isDisabled="!isSubmitEnabled"
+        @click="clearAnswer"
+        data-test="ClearButton"
+      ></icon-button>
+
+      <!-- save & next button -->
+      <icon-button
+        :titleConfig="saveNextButtonTitleConfig"
+        :buttonClass="saveNextButtonClass"
+        :isDisabled="!isAnswerSubmitted && !isSubmitEnabled"
+        @click="saveQuestionAndProceed"
+        data-test="saveAndNextButton"
+      ></icon-button>
+    </div>
+
+    <div class="place-self-end flex h-full">
       <!-- submit/continue button -->
       <icon-button
+        v-if="!isQuizAssessment"
         :titleConfig="submitButtonTitleConfig"
         :buttonClass="submitButtonClass"
         :isDisabled="!isAnswerSubmitted && !isSubmitEnabled"
         @click="submitQuestion"
         data-test="submitButton"
+      ></icon-button>
+      <!-- forward button -->
+      <icon-button
+        v-if="isQuizAssessment"
+        :iconConfig="nextQuestionButtonIconConfig"
+        :buttonClass="assessmentNavigationButtonClass"
+        ariaLabel="Next Question"
+        @click="goToNextQuestion"
+        data-test="nextQuestionButton"
       ></icon-button>
     </div>
   </div>
@@ -29,8 +66,19 @@
 
 <script lang="ts">
 import IconButton from "../UI/Buttons/IconButton.vue";
-import { IconButtonIconConfig } from "../../types";
-import { defineComponent, reactive, toRefs, computed } from "vue";
+import {
+  IconButtonIconConfig,
+  IconButtonTitleConfig,
+  quizType,
+} from "../../types";
+import {
+  defineComponent,
+  ref,
+  reactive,
+  toRefs,
+  computed,
+  PropType,
+} from "vue";
 
 export default defineComponent({
   components: { IconButton },
@@ -47,23 +95,83 @@ export default defineComponent({
       default: false,
       type: Boolean,
     },
+    quizType: {
+      type: String as PropType<quizType>,
+      default: "homework",
+    },
   },
   setup(props, context) {
+    const isQuizAssessment = computed(() => props.quizType == "assessment");
     const state = reactive({
-      previousQuestionButtonIconConfig: {
-        enabled: true,
-        iconName: "right-arrow",
-        iconClass: "text-yellow-800 transform rotate-180 fill-current h-6 w-4",
-      } as IconButtonIconConfig,
+      assessmentNavigationButtonIconClass: [
+        {
+          "text-yellow-800": !isQuizAssessment.value,
+          "text-gray-600": isQuizAssessment.value,
+        },
+        "fill-current h-6 w-4",
+      ],
+      assessmentNavigationButtonClass: [
+        {
+          "bg-yellow-500 hover:bg-yellow-600 ring-yellow-500":
+            !isQuizAssessment.value,
+          "bg-white hover:bg-gray-100": isQuizAssessment.value,
+        },
+        "p-2 px-6 bp-500:p-4 bp-500:px-8 rounded-2xl shadow-xl",
+      ],
+      clearButtonTitleConfig: {
+        value: "Clear",
+        class:
+          "text-gray-600 text-md bp-500:text-lg lg:text-xl xl:text-2xl font-bold",
+      } as IconButtonTitleConfig,
+      saveNextButtonTitleConfig: {
+        value: "Save & Next",
+        class:
+          "text-emerald-500 text-md bp-500:text-lg lg:text-xl xl:text-2xl font-bold",
+      } as IconButtonTitleConfig,
+      textButtonClass:
+        "p-4 px-8 bp-500:p-6 bp-500:px-12 rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
     });
+
+    const previousQuestionButtonIconConfig = ref({
+      enabled: true,
+      iconName: "right-arrow",
+      iconClass: [
+        state.assessmentNavigationButtonIconClass,
+        "transform rotate-180",
+      ],
+    } as IconButtonIconConfig);
+
+    const nextQuestionButtonIconConfig = ref({
+      enabled: true,
+      iconName: "right-arrow",
+      iconClass: state.assessmentNavigationButtonIconClass,
+    } as IconButtonIconConfig);
+
+    const clearButtonClass = ref([
+      state.textButtonClass,
+      "bg-white hover:bg-gray-50",
+    ]);
+
+    const saveNextButtonClass = ref([
+      state.textButtonClass,
+      "bg-white hover:bg-gray-50",
+    ]);
 
     function submitQuestion() {
       if (props.isAnswerSubmitted) context.emit("continue");
       else context.emit("submit");
     }
 
-    function gotToPreviousQuestion() {
+    function clearAnswer() {
+      context.emit("clear");
+    }
+
+    function goToPreviousQuestion() {
       context.emit("previous");
+    }
+
+    function goToNextQuestion() {
+      context.emit("continue");
     }
 
     const submitButtonTitleConfig = computed(() => {
@@ -71,7 +179,7 @@ export default defineComponent({
         value: props.isAnswerSubmitted ? "Continue" : "Submit",
         class:
           "text-white text-md bp-500:text-lg lg:text-xl xl:text-2xl font-bold",
-      };
+      } as IconButtonTitleConfig;
     });
 
     const submitButtonClass = computed(() => [
@@ -81,17 +189,24 @@ export default defineComponent({
         "bg-primary hover:bg-primary-hover ring-primary":
           props.isAnswerSubmitted,
       },
-      `p-4 px-8 bp-500:p-6 bp-500:px-12 rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none`,
+      state.textButtonClass,
     ]);
 
     return {
       ...toRefs(state),
+      previousQuestionButtonIconConfig,
+      nextQuestionButtonIconConfig,
+      clearButtonClass,
+      saveNextButtonClass,
       submitQuestion,
-      gotToPreviousQuestion,
+      goToPreviousQuestion,
+      goToNextQuestion,
+      clearAnswer,
       submitButtonTitleConfig,
       submitButtonClass,
+      isQuizAssessment,
     };
   },
-  emits: ["submit", "previous", "continue"],
+  emits: ["submit", "previous", "continue", "clear"],
 });
 </script>

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="flex w-full p-4 lg:p-6 justify-between"
+    class="flex w-full lg:p-6 justify-between"
     :class="{
-      'bg-white': !isQuizAssessment,
-      'bg-gray-200': isQuizAssessment,
+      'bg-white p-4': !isQuizAssessment,
+      'bg-gray-200 py-4 px-2': isQuizAssessment,
     }"
   >
     <div class="place-self-start flex h-full">
@@ -21,7 +21,7 @@
       ></icon-button>
     </div>
 
-    <div v-if="isQuizAssessment" class="flex space-x-4">
+    <div v-if="isQuizAssessment" class="flex space-x-1 sm:space-x-4">
       <!-- clear button -->
       <icon-button
         :titleConfig="clearButtonTitleConfig"
@@ -105,31 +105,25 @@ export default defineComponent({
     const state = reactive({
       assessmentNavigationButtonIconClass: [
         {
-          "text-yellow-800": !isQuizAssessment.value,
-          "text-gray-600": isQuizAssessment.value,
+          "text-yellow-800 h-6 w-4": !isQuizAssessment.value,
+          "text-gray-600 h-3 w-2 sm:h-5 sm:w-3 lg:h-6 lg:w-4":
+            isQuizAssessment.value,
         },
-        "fill-current h-6 w-4",
+        "fill-current",
       ],
+      assessmentTextButtonTitleClass:
+        "text-sm bp-500:text-md lg:text-lg xl:text-xl font-bold",
       assessmentNavigationButtonClass: [
         {
-          "bg-yellow-500 hover:bg-yellow-600 ring-yellow-500":
+          "bg-yellow-500 hover:bg-yellow-600 ring-yellow-500 px-6 bp-500:px-8 rounded-2xl":
             !isQuizAssessment.value,
-          "bg-white hover:bg-gray-100": isQuizAssessment.value,
+          "bg-white hover:bg-gray-100 px-4 bp-500:px-6 rounded-lg sm:rounded-xl lg:rounded-2xl":
+            isQuizAssessment.value,
         },
-        "p-2 px-6 bp-500:p-4 bp-500:px-8 rounded-2xl shadow-xl",
+        "p-2 bp-500:p-4 shadow-xl",
       ],
-      clearButtonTitleConfig: {
-        value: "Clear",
-        class:
-          "text-gray-600 text-md bp-500:text-lg lg:text-xl xl:text-2xl font-bold",
-      } as IconButtonTitleConfig,
-      saveNextButtonTitleConfig: {
-        value: "Save & Next",
-        class:
-          "text-emerald-500 text-md bp-500:text-lg lg:text-xl xl:text-2xl font-bold",
-      } as IconButtonTitleConfig,
-      textButtonClass:
-        "p-4 px-8 bp-500:p-6 bp-500:px-12 rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
+      assessmentTextButtonClass:
+        "p-2 px-4 bp-500:p-4 bp-500:px-6 rounded-lg sm:rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
     });
 
     const previousQuestionButtonIconConfig = ref({
@@ -148,14 +142,24 @@ export default defineComponent({
     } as IconButtonIconConfig);
 
     const clearButtonClass = ref([
-      state.textButtonClass,
+      state.assessmentTextButtonClass,
       "bg-white hover:bg-gray-50",
     ]);
 
     const saveNextButtonClass = ref([
-      state.textButtonClass,
+      state.assessmentTextButtonClass,
       "bg-white hover:bg-gray-50",
     ]);
+
+    const clearButtonTitleConfig = ref({
+      value: "Clear",
+      class: [state.assessmentTextButtonTitleClass, "text-gray-600"],
+    } as IconButtonTitleConfig);
+
+    const saveNextButtonTitleConfig = ref({
+      value: "Save & Next",
+      class: [state.assessmentTextButtonTitleClass, "text-emerald-500"],
+    } as IconButtonTitleConfig);
 
     function submitQuestion() {
       if (props.isAnswerSubmitted) context.emit("continue");
@@ -189,7 +193,7 @@ export default defineComponent({
         "bg-primary hover:bg-primary-hover ring-primary":
           props.isAnswerSubmitted,
       },
-      state.textButtonClass,
+      "p-4 px-8 bp-500:p-6 bp-500:px-12 rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
     ]);
 
     return {
@@ -198,6 +202,8 @@ export default defineComponent({
       nextQuestionButtonIconConfig,
       clearButtonClass,
       saveNextButtonClass,
+      clearButtonTitleConfig,
+      saveNextButtonTitleConfig,
       submitQuestion,
       goToPreviousQuestion,
       goToNextQuestion,

--- a/src/components/Questions/Header.vue
+++ b/src/components/Questions/Header.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="flex w-full justify-end bg-gray-100 p-4">
+    <!-- end-test button -->
+    <icon-button
+      :titleConfig="endTestButtonTitleConfig"
+      :buttonClass="endTestButtonClass"
+      @click="endTest"
+      data-test="endTestButton"
+    ></icon-button>
+  </div>
+</template>
+
+<script lang="ts">
+import IconButton from "../UI/Buttons/IconButton.vue";
+import { defineComponent, reactive, toRefs } from "vue";
+
+export default defineComponent({
+  name: "Header",
+  setup(_, context) {
+    const state = reactive({
+      endTestButtonClass:
+        "bg-emerald-500 hover:bg-emerald-600 ring-emerald-500 p-2 px-4 bp-500:p-4 bp-500:px-6 rounded-lg sm:rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
+      endTestButtonTitleConfig: {
+        value: "End Test",
+        class:
+          "text-white text-sm bp-500:text-md lg:text-lg xl:text-xl font-bold",
+      },
+    });
+    function endTest() {
+      context.emit("end-test");
+    }
+    return {
+      ...toRefs(state),
+      endTest,
+    };
+  },
+  components: {
+    IconButton,
+  },
+  emits: ["end-test"],
+});
+</script>

--- a/src/components/Questions/Header.vue
+++ b/src/components/Questions/Header.vue
@@ -12,26 +12,34 @@
 
 <script lang="ts">
 import IconButton from "../UI/Buttons/IconButton.vue";
-import { defineComponent, reactive, toRefs } from "vue";
+import { defineComponent, reactive, toRefs, computed } from "vue";
 
 export default defineComponent({
   name: "Header",
-  setup(_, context) {
+  props: {
+    hasQuizEnded: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props, context) {
     const state = reactive({
       endTestButtonClass:
         "bg-emerald-500 hover:bg-emerald-600 ring-emerald-500 p-2 px-4 bp-500:p-4 bp-500:px-6 rounded-lg sm:rounded-2xl shadow-xl disabled:opacity-50 disabled:pointer-events-none",
-      endTestButtonTitleConfig: {
-        value: "End Test",
-        class:
-          "text-white text-sm bp-500:text-md lg:text-lg xl:text-xl font-bold",
-      },
     });
     function endTest() {
       context.emit("end-test");
     }
+    const endTestButtonTitleConfig = computed(() => ({
+      value: props.hasQuizEnded ? "See Results" : "End Test",
+      class:
+        "text-white text-sm bp-500:text-md lg:text-lg xl:text-xl font-bold",
+    }));
+
     return {
       ...toRefs(state),
       endTest,
+      endTestButtonTitleConfig,
     };
   },
   components: {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -18,6 +18,7 @@
         :submittedAnswer="currentQuestionResponseAnswer"
         :isAnswerSubmitted="isAnswerSubmitted"
         :quizType="quizType"
+        :hasQuizEnded="hasQuizEnded"
         @option-selected="questionOptionSelected"
         @answer-entered="subjectiveAnswerUpdated"
         data-test="body"
@@ -27,6 +28,7 @@
         :isPreviousButtonShown="currentQuestionIndex > 0"
         :isSubmitEnabled="isAttemptValid"
         :quizType="quizType"
+        :hasQuizEnded="hasQuizEnded"
         @submit="submitQuestion"
         @continue="showNextQuestion"
         @previous="showPreviousQuestion"
@@ -73,6 +75,10 @@ export default defineComponent({
     currentQuestionIndex: {
       type: Number,
       default: 0,
+    },
+    hasQuizEnded: {
+      type: Boolean,
+      default: false,
     },
     responses: {
       required: true,
@@ -180,6 +186,7 @@ export default defineComponent({
 
     function endTest() {
       state.localCurrentQuestionIndex = props.questions.length;
+      context.emit("end-test");
     }
 
     onUnmounted(() => {
@@ -265,6 +272,11 @@ export default defineComponent({
       isQuizAssessment,
     };
   },
-  emits: ["update:currentQuestionIndex", "update:responses", "submit-question"],
+  emits: [
+    "update:currentQuestionIndex",
+    "update:responses",
+    "submit-question",
+    "end-test",
+  ],
 });
 </script>

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -150,6 +150,7 @@ export default defineComponent({
     }
 
     function submitQuestion() {
+      if (!state.localResponses.length) return;
       state.localResponses[props.currentQuestionIndex].answer =
         state.draftResponses[props.currentQuestionIndex];
       context.emit("submit-question");

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -204,7 +204,7 @@ export default defineComponent({
     );
 
     const currentQuestionResponseAnswer = computed(
-      () => currentQuestionResponse.value.answer
+      () => currentQuestionResponse.value?.answer
     );
 
     const isAnswerSubmitted = computed(() => {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="h-full flex flex-col">
-    <Header v-if="isQuizAssessment" @end-test="endTest"></Header>
+    <Header
+      v-if="isQuizAssessment"
+      @end-test="endTest"
+      :hasQuizEnded="hasQuizEnded"
+    ></Header>
     <div
       class="flex flex-col grow bg-white w-full justify-between overflow-hidden"
     >
@@ -59,6 +63,7 @@ import {
   DraftResponse,
   quizType,
 } from "../../types";
+import { useToast } from "vue-toastification";
 
 export default defineComponent({
   name: "QuestionModal",
@@ -95,6 +100,7 @@ export default defineComponent({
       localResponses: props.responses as SubmittedResponse[], // local copy of responses
       isPortrait: true,
       draftResponses: [] as DraftResponse[], // stores the options selected by the user but not yet submitted
+      toast: useToast(),
     });
 
     function checkScreenOrientation() {
@@ -172,7 +178,14 @@ export default defineComponent({
     }
 
     function showNextQuestion() {
-      state.localCurrentQuestionIndex = state.localCurrentQuestionIndex + 1;
+      if (
+        state.localCurrentQuestionIndex < props.questions.length - 1 ||
+        props.hasQuizEnded
+      ) {
+        state.localCurrentQuestionIndex = state.localCurrentQuestionIndex + 1;
+      } else {
+        state.toast.success('Click on "End Test" to submit your answers');
+      }
     }
 
     function showPreviousQuestion() {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -225,8 +225,8 @@ export default defineComponent({
     });
 
     // instantiating draftResponses here
-    props.questions.forEach(() => {
-      state.draftResponses.push(null);
+    props.responses.forEach((response) => {
+      state.draftResponses.push(response.answer);
     });
 
     // determine the screen orientation when the item modal is created

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -65,7 +65,7 @@ import {
   DraftResponse,
   quizType,
 } from "../../types";
-import { useToast } from "vue-toastification";
+import { useToast, POSITION } from "vue-toastification";
 
 export default defineComponent({
   name: "QuestionModal",
@@ -191,7 +191,10 @@ export default defineComponent({
         state.localCurrentQuestionIndex = state.localCurrentQuestionIndex + 1;
       } else {
         state.toast.success(
-          'No more questions, please press "End Test" if you are done'
+          'No more questions, please press "End Test" if you are done',
+          {
+            position: POSITION.TOP_LEFT,
+          }
         );
       }
     }

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -15,6 +15,7 @@
       :draftAnswer="draftResponses[currentQuestionIndex]"
       :submittedAnswer="currentQuestionResponseAnswer"
       :isAnswerSubmitted="isAnswerSubmitted"
+      :quizType="quizType"
       @option-selected="questionOptionSelected"
       @answer-entered="subjectiveAnswerUpdated"
       data-test="body"
@@ -27,6 +28,7 @@
       @submit="submitQuestion"
       @continue="showNextQuestion"
       @previous="showPreviousQuestion"
+      @clear="clearAnswer"
       data-test="footer"
     ></Footer>
   </div>
@@ -153,6 +155,10 @@ export default defineComponent({
       context.emit("submit-question");
     }
 
+    function clearAnswer() {
+      state.draftResponses[props.currentQuestionIndex] = null;
+    }
+
     function showNextQuestion() {
       state.localCurrentQuestionIndex = state.localCurrentQuestionIndex + 1;
     }
@@ -235,6 +241,7 @@ export default defineComponent({
       showNextQuestion,
       showPreviousQuestion,
       subjectiveAnswerUpdated,
+      clearAnswer,
       currentQuestion,
       questionType,
       questionCorrectAnswer,

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -184,7 +184,8 @@ export default defineComponent({
       resetState();
       if (
         state.localCurrentQuestionIndex < props.questions.length - 1 ||
-        props.hasQuizEnded
+        props.hasQuizEnded ||
+        !isQuizAssessment.value
       ) {
         state.localCurrentQuestionIndex = state.localCurrentQuestionIndex + 1;
       } else {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -191,7 +191,7 @@ export default defineComponent({
         state.localCurrentQuestionIndex = state.localCurrentQuestionIndex + 1;
       } else {
         state.toast.success(
-          'No more questions, please press "End Test" if you are done',
+          'No more questions, please press "End Test" if you are done 👉',
           {
             position: POSITION.TOP_LEFT,
           }

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -184,7 +184,9 @@ export default defineComponent({
       ) {
         state.localCurrentQuestionIndex = state.localCurrentQuestionIndex + 1;
       } else {
-        state.toast.success('Click on "End Test" to submit your answers');
+        state.toast.success(
+          'No more questions, please press "End Test" if you are done'
+        );
       }
     }
 

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -21,6 +21,7 @@
         :draftAnswer="draftResponses[currentQuestionIndex]"
         :submittedAnswer="currentQuestionResponseAnswer"
         :isAnswerSubmitted="isAnswerSubmitted"
+        :isDraftAnswerCleared="isDraftAnswerCleared"
         :quizType="quizType"
         :hasQuizEnded="hasQuizEnded"
         @option-selected="questionOptionSelected"
@@ -101,6 +102,7 @@ export default defineComponent({
       isPortrait: true,
       draftResponses: [] as DraftResponse[], // stores the options selected by the user but not yet submitted
       toast: useToast(),
+      isDraftAnswerCleared: false, // whether the draft answer has been cleared but not yet submitted
     });
 
     function checkScreenOrientation() {
@@ -175,9 +177,11 @@ export default defineComponent({
 
     function clearAnswer() {
       state.draftResponses[props.currentQuestionIndex] = null;
+      state.isDraftAnswerCleared = true;
     }
 
     function showNextQuestion() {
+      resetState();
       if (
         state.localCurrentQuestionIndex < props.questions.length - 1 ||
         props.hasQuizEnded
@@ -191,7 +195,21 @@ export default defineComponent({
     }
 
     function showPreviousQuestion() {
+      resetState();
       state.localCurrentQuestionIndex -= 1;
+    }
+
+    function resetState() {
+      if (
+        state.isDraftAnswerCleared &&
+        isQuestionTypeSubjective.value &&
+        state.draftResponses[props.currentQuestionIndex] !=
+          currentQuestionResponseAnswer.value
+      ) {
+        state.draftResponses[props.currentQuestionIndex] =
+          currentQuestionResponseAnswer.value;
+      }
+      state.isDraftAnswerCleared = false;
     }
 
     /** update the attempt to the current question - valid for subjective questions */

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -31,6 +31,7 @@
       <Footer
         :isAnswerSubmitted="isAnswerSubmitted"
         :isPreviousButtonShown="currentQuestionIndex > 0"
+        :isNextButtonShown="currentQuestionIndex != questions.length - 1"
         :isSubmitEnabled="isAttemptValid"
         :quizType="quizType"
         :hasQuizEnded="hasQuizEnded"

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -23,6 +23,7 @@
       :isAnswerSubmitted="isAnswerSubmitted"
       :isPreviousButtonShown="currentQuestionIndex > 0"
       :isSubmitEnabled="isAttemptValid"
+      :quizType="quizType"
       @submit="submitQuestion"
       @continue="showNextQuestion"
       @previous="showPreviousQuestion"
@@ -44,7 +45,12 @@ import {
   watch,
 } from "vue";
 import { isScreenPortrait } from "../../services/Functional/Utilities";
-import { Question, SubmittedResponse, DraftResponse } from "../../types";
+import {
+  Question,
+  SubmittedResponse,
+  DraftResponse,
+  quizType,
+} from "../../types";
 
 export default defineComponent({
   name: "QuestionModal",
@@ -64,6 +70,10 @@ export default defineComponent({
     responses: {
       required: true,
       type: Array as PropType<SubmittedResponse[]>,
+    },
+    quizType: {
+      type: String as PropType<quizType>,
+      default: "homework",
     },
   },
   setup(props, context) {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -1,42 +1,46 @@
 <template>
-  <div
-    class="flex flex-col bg-white w-full h-full justify-between overflow-hidden"
-  >
-    <Body
-      class="mt-10"
-      :text="currentQuestion.text"
-      :options="currentQuestion.options"
-      :correctAnswer="questionCorrectAnswer"
-      :questionType="questionType"
-      :isGradedQuestion="isGradedQuestion"
-      :maxCharLimit="currentQuestion.max_char_limit"
-      :isPortrait="isPortrait"
-      :imageData="currentQuestion?.image"
-      :draftAnswer="draftResponses[currentQuestionIndex]"
-      :submittedAnswer="currentQuestionResponseAnswer"
-      :isAnswerSubmitted="isAnswerSubmitted"
-      :quizType="quizType"
-      @option-selected="questionOptionSelected"
-      @answer-entered="subjectiveAnswerUpdated"
-      data-test="body"
-    ></Body>
-    <Footer
-      :isAnswerSubmitted="isAnswerSubmitted"
-      :isPreviousButtonShown="currentQuestionIndex > 0"
-      :isSubmitEnabled="isAttemptValid"
-      :quizType="quizType"
-      @submit="submitQuestion"
-      @continue="showNextQuestion"
-      @previous="showPreviousQuestion"
-      @clear="clearAnswer"
-      data-test="footer"
-    ></Footer>
+  <div class="h-full flex flex-col">
+    <Header v-if="isQuizAssessment" @end-test="endTest"></Header>
+    <div
+      class="flex flex-col grow bg-white w-full justify-between overflow-hidden"
+    >
+      <Body
+        class="mt-10"
+        :text="currentQuestion.text"
+        :options="currentQuestion.options"
+        :correctAnswer="questionCorrectAnswer"
+        :questionType="questionType"
+        :isGradedQuestion="isGradedQuestion"
+        :maxCharLimit="currentQuestion.max_char_limit"
+        :isPortrait="isPortrait"
+        :imageData="currentQuestion?.image"
+        :draftAnswer="draftResponses[currentQuestionIndex]"
+        :submittedAnswer="currentQuestionResponseAnswer"
+        :isAnswerSubmitted="isAnswerSubmitted"
+        :quizType="quizType"
+        @option-selected="questionOptionSelected"
+        @answer-entered="subjectiveAnswerUpdated"
+        data-test="body"
+      ></Body>
+      <Footer
+        :isAnswerSubmitted="isAnswerSubmitted"
+        :isPreviousButtonShown="currentQuestionIndex > 0"
+        :isSubmitEnabled="isAttemptValid"
+        :quizType="quizType"
+        @submit="submitQuestion"
+        @continue="showNextQuestion"
+        @previous="showPreviousQuestion"
+        @clear="clearAnswer"
+        data-test="footer"
+      ></Footer>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import Body from "./Body.vue";
 import Footer from "./Footer.vue";
+import Header from "./Header.vue";
 import {
   defineComponent,
   PropType,
@@ -59,6 +63,7 @@ export default defineComponent({
   components: {
     Body,
     Footer,
+    Header,
   },
   props: {
     questions: {
@@ -173,6 +178,10 @@ export default defineComponent({
       state.draftResponses[props.currentQuestionIndex] = answer;
     }
 
+    function endTest() {
+      state.localCurrentQuestionIndex = props.questions.length;
+    }
+
     onUnmounted(() => {
       // remove listeners
       window.removeEventListener("resize", checkScreenOrientation);
@@ -225,6 +234,8 @@ export default defineComponent({
       return currentDraftResponse.length > 0;
     });
 
+    const isQuizAssessment = computed(() => props.quizType == "assessment");
+
     // instantiating draftResponses here
     props.responses.forEach((response) => {
       state.draftResponses.push(response.answer);
@@ -243,6 +254,7 @@ export default defineComponent({
       showPreviousQuestion,
       subjectiveAnswerUpdated,
       clearAnswer,
+      endTest,
       currentQuestion,
       questionType,
       questionCorrectAnswer,
@@ -250,6 +262,7 @@ export default defineComponent({
       currentQuestionResponseAnswer,
       isAnswerSubmitted,
       isAttemptValid,
+      isQuizAssessment,
     };
   },
   emits: ["update:currentQuestionIndex", "update:responses", "submit-question"],

--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -43,15 +43,15 @@
         <!-- metric boxes -->
         <div
           v-if="hasGradedQuestions"
-          class="flex bp-500:flex-row justify-center space-x-6 px-4 bp-500:px-10 max-w-4xl place-self-center"
+          class="flex flex-col bp-500:flex-row justify-center space-y-1 bp-500:space-x-1 bp-500:space-y-0 px-4 bp-500:px-10 max-w-4xl place-self-center"
         >
           <div
             v-for="metric in metrics"
-            class="rounded-2xl bg-[#FFB830] grid grid-rows-2 grid-cols-none border-2 px-4 lg:px-6 h-16 bp-500:h-20 min-w-max"
+            class="rounded-md bp-500:rounded-2xl bg-amber-400 grid grid-cols-2 bp-500:grid-rows-2 bp-500:grid-cols-none lg:grid-cols-2 lg:grid-rows-none border-2 px-4 lg:px-6 w-full h-14 bp-500:h-20 min-w-max"
             :key="metric"
           >
             <div
-              class="w-full h-full flex flex-row justify-center space-x-1 bp-500:space-x-3 bp-500:mt-1"
+              class="w-full h-full flex flex-row justify-center space-x-2 bp-500:mt-2 lg:mt-0"
             >
               <!-- metric icon -->
               <BaseIcon
@@ -60,14 +60,14 @@
               ></BaseIcon>
               <!-- numeric value of the metric -->
               <p
-                class="text-[32px] md:text-[42px] lg:text-5xl font-bold md:leading-none"
+                class="text-xl bp-360:text-2xl md:text-3xl lg:text-4xl font-bold my-auto"
               >
                 {{ metric.value }}
               </p>
             </div>
             <!-- name of the metric -->
             <div
-              class="text-center text-sm bp-320:text-xs md:text-base font-medium mt-1 lg:mt-2 bp-500:whitespace-nowrap px-1 h-full flex place-self-center items-center"
+              class="text-center text-xs bp-500:text-sm md:text-base mt-1 lg:mt-2 bp-500:whitespace-nowrap px-1 h-full flex place-self-center items-center"
             >
               <p>
                 {{ metric.name }}

--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -46,7 +46,7 @@
           class="flex flex-col bp-500:flex-row justify-center space-y-1 bp-500:space-x-1 bp-500:space-y-0 px-4 bp-500:px-10 max-w-4xl place-self-center"
         >
           <div
-            v-for="metric in metrics"
+            v-for="(metric, metricIndex) in metrics"
             class="rounded-md bp-500:rounded-2xl bg-amber-400 grid grid-cols-2 bp-500:grid-rows-2 bp-500:grid-cols-none lg:grid-cols-2 lg:grid-rows-none border-2 px-4 lg:px-6 w-full h-14 bp-500:h-20 min-w-max"
             :key="metric"
           >
@@ -61,6 +61,7 @@
               <!-- numeric value of the metric -->
               <p
                 class="text-xl bp-360:text-2xl md:text-3xl lg:text-4xl font-bold my-auto"
+                :data-test="`metricValue-${metricIndex}`"
               >
                 {{ metric.value }}
               </p>

--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -47,7 +47,9 @@
           <div :class="metadataCellClass">
             <BaseIcon name="notepad" :iconClass="metadataIconClass"></BaseIcon>
             <div class="flex items-center" data-test="quizType">
-              <p :class="metadataTitleClass">{{ quizType }}</p>
+              <p class="capitalize" :class="metadataTitleClass">
+                {{ quizType }}
+              </p>
             </div>
           </div>
         </div>
@@ -68,7 +70,8 @@
 <script lang="ts">
 import IconButton from "./UI/Buttons/IconButton.vue";
 import BaseIcon from "./UI/Icons/BaseIcon.vue";
-import { defineComponent, computed, reactive, toRefs } from "vue";
+import { quizType } from "../types";
+import { defineComponent, computed, reactive, toRefs, PropType } from "vue";
 export default defineComponent({
   name: "Splash",
   components: {
@@ -85,7 +88,7 @@ export default defineComponent({
       required: true,
     },
     quizType: {
-      type: String,
+      type: String as PropType<quizType>,
       required: true,
     },
     numQuestions: {

--- a/src/components/UI/Buttons/IconButton.vue
+++ b/src/components/UI/Buttons/IconButton.vue
@@ -89,6 +89,7 @@ export default defineComponent({
       const localCopy = props.titleConfig;
       Object.entries(state.defaultTitleConfig).forEach(([key, val]) => {
         if (!(key in localCopy)) {
+          // @ts-ignore
           localCopy[key as keyof IconButtonTitleConfig] = val;
         }
       });

--- a/src/components/UI/Icons/BaseIcon.vue
+++ b/src/components/UI/Icons/BaseIcon.vue
@@ -11,6 +11,7 @@
     <RightArrow v-if="name == 'right-arrow'"></RightArrow>
     <Warning v-if="name == 'warning'"></Warning>
     <Lock v-if="name == 'lock'"></Lock>
+    <Skip v-if="name == 'skip'"></Skip>
   </div>
 </template>
 
@@ -26,6 +27,7 @@ import SpinnerSolid from "./SpinnerSolid.vue";
 import RightArrow from "./RightArrow.vue";
 import Warning from "./Warning.vue";
 import Lock from "./Lock.vue";
+import Skip from "./Skip.vue";
 
 export default {
   name: "BaseIcon",
@@ -41,6 +43,7 @@ export default {
     RightArrow,
     Warning,
     Lock,
+    Skip,
   },
   props: {
     name: {

--- a/src/components/UI/Icons/Skip.vue
+++ b/src/components/UI/Icons/Skip.vue
@@ -1,0 +1,24 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    version="1.1"
+    x="0px"
+    y="0px"
+    viewBox="0 0 100 100"
+    style="enable-background: new 0 0 100 100"
+    xml:space="preserve"
+  >
+    <g transform="translate(319.000000, 195.000000)">
+      <path
+        d="M-269-110c-19.3,0-35-15.7-35-35s15.7-35,35-35s35,15.7,35,35S-249.7-110-269-110z M-269-115.4   c16.3,0,29.6-13.2,29.6-29.6s-13.2-29.6-29.6-29.6s-29.6,13.2-29.6,29.6S-285.3-115.4-269-115.4z M-258.7-147.7   c1.7,0,3.1,1.2,3.1,2.7s-1.4,2.7-3.1,2.7h-20.7c-1.7,0-3.1-1.2-3.1-2.7s1.4-2.7,3.1-2.7H-258.7z"
+      ></path>
+    </g>
+  </svg>
+</template>
+
+<script>
+export default {
+  name: "Skip",
+};
+</script>

--- a/src/components/UI/Progress/CircularProgress.vue
+++ b/src/components/UI/Progress/CircularProgress.vue
@@ -67,13 +67,6 @@ export default defineComponent({
      * - whether it is enabled and its title
      */
     result: {
-      default: () => {
-        return {
-          enabled: false,
-          title: "",
-          value: Number,
-        };
-      },
       type: Object,
       required: true,
     },

--- a/src/components/UI/Text/Textarea.vue
+++ b/src/components/UI/Text/Textarea.vue
@@ -84,7 +84,6 @@ export default defineComponent({
       }
     }
     function keyPress(event: KeyboardEvent) {
-      console.log("oh yeah");
       // invoked by pressing a key
       context.emit("keypress", event);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import App from "./App.vue";
 import router from "./router";
 import store from "./store";
 import Toast, { ToastInterface } from "vue-toastification";
-// import { ToastComponent } from "vue-toastification";
 
 import "./index.css";
 import "vue-toastification/dist/index.css";

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,29 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
 import store from "./store";
-import Toast from "vue-toastification";
+import Toast, { ToastInterface } from "vue-toastification";
+// import { ToastComponent } from "vue-toastification";
 
 import "./index.css";
 import "vue-toastification/dist/index.css";
 
 const app = createApp(App).use(store).use(router);
-app.use(Toast);
+
+const filterBeforeCreate = (
+  toast: ToastInterface,
+  toasts: ToastInterface[]
+) => {
+  // adapted from here - https://github.com/Maronato/vue-toastification#filterbeforecreate
+  // prevents toasts with the same content from appearing simultaneously, discarding duplicates
+  // and prevent toasts from showing up for an embedded plio
+  // @ts-ignore
+  if (toasts.filter((t) => t.content === toast.content).length !== 0) {
+    // returning false discards the toast
+    return false;
+  }
+  return toast;
+};
+
+app.use(Toast, { filterBeforeCreate });
 
 app.mount("#app");

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,12 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
 import store from "./store";
+import Toast from "vue-toastification";
+
 import "./index.css";
+import "vue-toastification/dist/index.css";
 
 const app = createApp(App).use(store).use(router);
+app.use(Toast);
 
 app.mount("#app");

--- a/src/services/API/Session.ts
+++ b/src/services/API/Session.ts
@@ -25,6 +25,21 @@ export default {
   },
 
   /**
+   * @param sessionId - id of the session to be updated
+   * @param hasQuizEnded - whether the quiz has ended
+   * @returns {Promise<SessionAPIResponse>} data corresponding to the updated session
+   */
+  async updateSession(
+    sessionId: string,
+    hasQuizEnded: boolean
+  ): Promise<SessionAPIResponse> {
+    const response = await apiClient().patch(sessionsEndpoint + sessionId, {
+      has_quiz_ended: hasQuizEnded,
+    });
+    return response.data;
+  },
+
+  /**
    * @param {string} sessionAnswerId - id of the sessionAnswer instance to update
    * @param {submittedAnswer} answer - the answer that needs to be updated
    * @returns {Promise<SessionAnswerAPIResponse>} - the updated sessionAnswer instance

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export interface SessionAPIResponse {
   quiz_id: string;
   is_first: boolean;
   session_answers: SubmittedResponse[];
+  has_quiz_ended?: boolean;
 }
 
 export interface SessionAnswerAPIResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ type correctAnswer = number[] | null;
 
 export interface IconButtonTitleConfig {
   value: string;
-  class?: string;
+  class?: string | string[];
 }
 
 export interface IconButtonIconConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
 type questionWithOptions = "single-choice" | "multi-choice";
 type questionType = questionWithOptions | "subjective";
 type language = "en" | "hi";
-type quizType = "assessment" | "homework";
+export type quizType = "assessment" | "homework";
 type quizNavigationMode = "linear" | "non-linear";
 export type submittedAnswer = number[] | string | null;
 type correctAnswer = number[] | null;
@@ -16,7 +16,7 @@ export interface IconButtonTitleConfig {
 export interface IconButtonIconConfig {
   enabled: boolean;
   iconName: string;
-  iconClass?: string;
+  iconClass?: string | string[];
 }
 
 export interface InputTextValidationConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
 type questionWithOptions = "single-choice" | "multi-choice";
 type questionType = questionWithOptions | "subjective";
 type language = "en" | "hi";
-type quizType = "assessment" | "JEE";
+type quizType = "assessment" | "homework";
 type quizNavigationMode = "linear" | "non-linear";
 export type submittedAnswer = number[] | string | null;
 type correctAnswer = number[] | null;

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -16,9 +16,11 @@
       <QuestionModal
         :questions="questions"
         :quizType="metadata.quiz_type"
+        :hasQuizEnded="hasQuizEnded"
         v-model:currentQuestionIndex="currentQuestionIndex"
         v-model:responses="responses"
         @submit-question="submitQuestion"
+        @end-test="endTest"
         v-if="isQuestionShown"
         data-test="modal"
       ></QuestionModal>
@@ -80,6 +82,8 @@ export default defineComponent({
       numWrong: 0, // number of wrongly answered questions
       numSkipped: 0, // number of skipped questions
       isScorecardShown: false, // to show the scorecard or not
+      hasQuizEnded: false, // whether the quiz has ended - only valid for quizType = assessment
+      sessionId: "", // id of the session created for a user-quiz combination
     });
     const isQuizAssessment = computed(
       () => state.metadata.quiz_type == "assessment"
@@ -124,8 +128,10 @@ export default defineComponent({
         props.quizId,
         route.query.userId as string
       );
+      state.sessionId = sessionDetails._id;
       state.responses = sessionDetails.session_answers;
       state.isFirstSession = sessionDetails.is_first;
+      state.hasQuizEnded = sessionDetails.has_quiz_ended || false;
     }
 
     async function getQuizCreateSession() {
@@ -141,6 +147,11 @@ export default defineComponent({
         itemResponse._id,
         itemResponse.answer
       );
+    }
+
+    function endTest() {
+      SessionAPIService.updateSession(state.sessionId, true);
+      state.hasQuizEnded = true;
     }
 
     getQuizCreateSession();
@@ -275,6 +286,7 @@ export default defineComponent({
       startQuiz,
       submitQuestion,
       goToPreviousQuestion,
+      endTest,
     };
   },
 });

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -15,6 +15,7 @@
 
       <QuestionModal
         :questions="questions"
+        :quizType="metadata.quiz_type"
         v-model:currentQuestionIndex="currentQuestionIndex"
         v-model:responses="responses"
         @submit-question="submitQuestion"

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -150,8 +150,10 @@ export default defineComponent({
     }
 
     function endTest() {
-      SessionAPIService.updateSession(state.sessionId, true);
-      state.hasQuizEnded = true;
+      if (!state.hasQuizEnded) {
+        SessionAPIService.updateSession(state.sessionId, true);
+        state.hasQuizEnded = true;
+      }
     }
 
     getQuizCreateSession();

--- a/tests/e2e/fixtures/assessment_quiz.json
+++ b/tests/e2e/fixtures/assessment_quiz.json
@@ -1,0 +1,88 @@
+{
+  "_id": "abcd",
+  "question_sets": [
+    {
+      "_id": "62540adb0f748c8e206c1613",
+      "questions": [
+        {
+          "_id": "62540adb0f748c8e206c1614",
+          "text": "Which grade are you in?",
+          "type": "single-choice",
+          "instructions": null,
+          "image": null,
+          "options": [
+            { "text": "Option 1", "image": null },
+            { "text": "Option 2", "image": null },
+            { "text": "Option 3", "image": null }
+          ],
+          "max_char_limit": null,
+          "correct_answer": [0],
+          "graded": true,
+          "marking_scheme": null,
+          "solution": [],
+          "metadata": null
+        },
+        {
+          "_id": "62540adb0f748c8e206c1615",
+          "text": "Which grade are you in?",
+          "type": "multi-choice",
+          "instructions": null,
+          "image": {
+            "url": "https://plio-prod-assets.s3.ap-south-1.amazonaws.com/images/afbxudrmbl.png",
+            "alt_text": "Image"
+          },
+          "options": [
+            { "text": "Option 1", "image": null },
+            {
+              "text": "Option 2",
+              "image": {
+                "url": "https://plio-prod-assets.s3.ap-south-1.amazonaws.com/images/afbxudrmbl.png",
+                "alt_text": null
+              }
+            },
+            { "text": "Option 3", "image": null }
+          ],
+          "max_char_limit": null,
+          "correct_answer": [0, 2],
+          "graded": true,
+          "marking_scheme": null,
+          "solution": [],
+          "metadata": null
+        },
+        {
+          "_id": "62540adb0f748c8e206c1616",
+          "text": "Which subject are you studying?",
+          "type": "multi-choice",
+          "instructions": null,
+          "image": null,
+          "options": [
+            { "text": "Option 1", "image": null },
+            { "text": "Option 2", "image": null },
+            { "text": "Option 3", "image": null }
+          ],
+          "max_char_limit": null,
+          "correct_answer": [1],
+          "graded": true,
+          "marking_scheme": null,
+          "solution": [],
+          "metadata": null
+        }
+      ]
+    }
+  ],
+  "max_marks": 10,
+  "num_graded_questions": 3,
+  "shuffle": false,
+  "num_attempts_allowed": 1,
+  "time_limit": null,
+  "navigation_mode": "linear",
+  "instructions": null,
+  "language": "en",
+  "metadata": {
+    "quiz_type": "assessment",
+    "grade": "8",
+    "subject": "Maths",
+    "chapter": null,
+    "topic": null
+  }
+}

--- a/tests/e2e/fixtures/homework_quiz.json
+++ b/tests/e2e/fixtures/homework_quiz.json
@@ -79,7 +79,7 @@
   "instructions": null,
   "language": "en",
   "metadata": {
-    "quiz_type": "JEE",
+    "quiz_type": "homework",
     "grade": "8",
     "subject": "Maths",
     "chapter": null,

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -151,9 +151,6 @@ describe("Player for Assessment quizzes", () => {
         cy.get('[data-test="modal"]')
           .get('[data-test="optionSelector-0"]')
           .trigger("click");
-        cy.get('[data-test="modal"]')
-          .get('[data-test="nextQuestionButton"]')
-          .trigger("click");
 
         // end test
         cy.get('[data-test="modal"]')

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -1,0 +1,249 @@
+// https://docs.cypress.io/api/introduction/api.html
+
+describe("Player for Assessment quizzes", () => {
+  beforeEach(() => {
+    // stub the response to /quiz/{quizId}
+    cy.intercept("GET", "/quiz/*", {
+      fixture: "assessment_quiz.json",
+    });
+  });
+
+  describe("New Session", () => {
+    beforeEach(() => {
+      // stub the response to /sessions
+      cy.intercept("POST", "/sessions/", {
+        fixture: "new_session.json",
+      });
+
+      cy.intercept("PATCH", "/session_answers/*", {});
+
+      cy.visit("/abcd?userId=1");
+
+      // define aliasas
+      cy.get('[data-test="startQuiz"]').as("startQuizButton");
+    });
+
+    it("shows splash screen", () => {
+      cy.get('[data-test="quizType"]').should("have.text", "assessment");
+    });
+
+    describe("Quiz Started", () => {
+      beforeEach(() => {
+        cy.get("@startQuizButton").trigger("click");
+      });
+
+      it("disables clear and save & next buttons", () => {
+        cy.get('[data-test="modal"]')
+          .get('[data-test="clearButton"]')
+          .should("be.disabled");
+        cy.get('[data-test="modal"]')
+          .get('[data-test="saveAndNextButton"]')
+          .should("be.disabled");
+      });
+
+      describe("Answer selected", () => {
+        beforeEach(() => {
+          // question 1
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .trigger("click");
+        });
+
+        it("enables clear and save & next buttons", () => {
+          cy.get('[data-test="modal"]')
+            .get('[data-test="clearButton"]')
+            .should("not.be.disabled");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="saveAndNextButton"]')
+            .should("not.be.disabled");
+        });
+
+        it("clears the answer upon clicking Clear", () => {
+          // option 1 should be selected
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .should("be.checked");
+
+          cy.get('[data-test="modal"]')
+            .get('[data-test="clearButton"]')
+            .trigger("click");
+
+          // option 1 should no longer be selected
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .should("not.be.checked");
+        });
+
+        it("submits the answer upon clicking Save & Next", () => {
+          cy.get('[data-test="modal"]')
+            .get('[data-test="saveAndNextButton"]')
+            .trigger("click");
+
+          // move back to the previous question
+          cy.get('[data-test="modal"]')
+            .get('[data-test="previousQuestionButton"]')
+            .trigger("click");
+
+          // only option 1 should be checked
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .should("be.checked");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-1"]')
+            .should("not.be.checked");
+
+          // only option 1 should have a gray background
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionContainer-0"]')
+            .should("have.class", "bg-gray-200");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionContainer-1"]')
+            .should("not.have.class", "bg-gray-200");
+        });
+
+        it("only moves to the next question without submitting the answer upon clicking Next", () => {
+          cy.get('[data-test="modal"]')
+            .get('[data-test="nextQuestionButton"]')
+            .trigger("click");
+
+          // move back to the previous question
+          cy.get('[data-test="modal"]')
+            .get('[data-test="previousQuestionButton"]')
+            .trigger("click");
+
+          // only option 1 should be checked
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .should("be.checked");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-1"]')
+            .should("not.be.checked");
+
+          // no option should have a gray background
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionContainer-0"]')
+            .should("not.have.class", "bg-gray-200");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionContainer-1"]')
+            .should("not.have.class", "bg-gray-200");
+        });
+      });
+      it("shows number of skipped questions in the scorecard too", () => {
+        // question 1
+        cy.get('[data-test="modal"]')
+          .get('[data-test="optionSelector-0"]')
+          .trigger("click");
+        cy.get('[data-test="modal"]')
+          .get('[data-test="saveAndNextButton"]')
+          .trigger("click");
+
+        // question 2
+        cy.get('[data-test="modal"]')
+          .get('[data-test="optionSelector-0"]')
+          .trigger("click");
+        cy.get('[data-test="modal"]')
+          .get('[data-test="saveAndNextButton"]')
+          .trigger("click");
+
+        // question 3
+        cy.get('[data-test="modal"]')
+          .get('[data-test="optionSelector-0"]')
+          .trigger("click");
+        cy.get('[data-test="modal"]')
+          .get('[data-test="nextQuestionButton"]')
+          .trigger("click");
+
+        cy.get('[data-test="scorecard"]')
+          .get('[data-test="metricValue-2"]')
+          .should("have.text", 1);
+      });
+    });
+  });
+
+  describe("Resume Session", () => {
+    beforeEach(() => {
+      // stub the response to /sessions
+      cy.intercept("POST", "/sessions/", {
+        fixture: "resume_session.json",
+      });
+
+      cy.visit("/abcd?userId=1");
+
+      // define aliasas
+      cy.get('[data-test="startQuiz"]').as("startQuizButton");
+    });
+
+    describe("updating answers of questions", () => {
+      beforeEach(() => {
+        cy.get("@startQuizButton").trigger("click");
+        cy.get('[data-test="modal"]').as("modal");
+      });
+
+      it("clears submitted answer upon clicking clear + save & next", () => {
+        // only option 1 should be checked
+        cy.get("@modal")
+          .get('[data-test="optionSelector-0"]')
+          .should("be.checked");
+        cy.get("@modal")
+          .get('[data-test="optionSelector-1"]')
+          .should("not.be.checked");
+
+        // only option 1 should be marked selected
+        cy.get("@modal")
+          .get('[data-test="optionContainer-0"]')
+          .should("have.class", "bg-gray-200");
+        cy.get("@modal")
+          .get('[data-test="optionContainer-1"]')
+          .should("not.have.class", "bg-gray-200");
+
+        cy.get('[data-test="modal"]')
+          .get('[data-test="clearButton"]')
+          .trigger("click");
+        cy.get('[data-test="modal"]')
+          .get('[data-test="saveAndNextButton"]')
+          .trigger("click");
+
+        // move back to the previous question
+        cy.get('[data-test="modal"]')
+          .get('[data-test="previousQuestionButton"]')
+          .trigger("click");
+
+        // option 1 should no longer be marked selected
+        cy.get("@modal")
+          .get('[data-test="optionContainer-0"]')
+          .should("not.have.class", "bg-gray-200");
+      });
+
+      it("updates submitted answer upon selecting new answer + clicking save & next", () => {
+        cy.get('[data-test="modal"]')
+          .get('[data-test="optionSelector-1"]')
+          .trigger("click");
+
+        cy.get('[data-test="modal"]')
+          .get('[data-test="saveAndNextButton"]')
+          .trigger("click");
+
+        // move back to the previous question
+        cy.get('[data-test="modal"]')
+          .get('[data-test="previousQuestionButton"]')
+          .trigger("click");
+
+        // option 1 should no longer be checked, option 2 should be checked
+        cy.get("@modal")
+          .get('[data-test="optionSelector-0"]')
+          .should("not.be.checked");
+        cy.get("@modal")
+          .get('[data-test="optionSelector-1"]')
+          .should("be.checked");
+
+        // option 1 should no longer be marked selected, option 2 should be
+        cy.get("@modal")
+          .get('[data-test="optionContainer-0"]')
+          .should("not.have.class", "bg-gray-200");
+        cy.get("@modal")
+          .get('[data-test="optionContainer-1"]')
+          .should("have.class", "bg-gray-200");
+      });
+    });
+  });
+});

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -130,6 +130,8 @@ describe("Player for Assessment quizzes", () => {
       });
 
       it("shows number of skipped questions in the scorecard too", () => {
+        cy.intercept("PATCH", "/sessions/*", {});
+
         // question 1
         cy.get('[data-test="modal"]')
           .get('[data-test="optionSelector-0"]')

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -16,6 +16,7 @@ describe("Player for Assessment quizzes", () => {
       });
 
       cy.intercept("PATCH", "/session_answers/*", {});
+      cy.intercept("PATCH", "/sessions/*", {});
 
       cy.visit("/abcd?userId=1");
 
@@ -130,8 +131,6 @@ describe("Player for Assessment quizzes", () => {
       });
 
       it("shows number of skipped questions in the scorecard too", () => {
-        cy.intercept("PATCH", "/sessions/*", {});
-
         // question 1
         cy.get('[data-test="modal"]')
           .get('[data-test="optionSelector-0"]')

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -154,6 +154,11 @@ describe("Player for Assessment quizzes", () => {
           .get('[data-test="nextQuestionButton"]')
           .trigger("click");
 
+        // end test
+        cy.get('[data-test="modal"]')
+          .get('[data-test="endTestButton"]')
+          .trigger("click");
+
         cy.get('[data-test="scorecard"]')
           .get('[data-test="metricValue-2"]')
           .should("have.text", 1);

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -128,6 +128,7 @@ describe("Player for Assessment quizzes", () => {
             .should("not.have.class", "bg-gray-200");
         });
       });
+
       it("shows number of skipped questions in the scorecard too", () => {
         // question 1
         cy.get('[data-test="modal"]')
@@ -156,6 +157,15 @@ describe("Player for Assessment quizzes", () => {
         cy.get('[data-test="scorecard"]')
           .get('[data-test="metricValue-2"]')
           .should("have.text", 1);
+      });
+
+      it("shows scorecard upon selecting End Test", () => {
+        cy.get('[data-test="modal"]')
+          .get('[data-test="endTestButton"]')
+          .trigger("click");
+
+        cy.get('[data-test="modal"]').should("not.exist");
+        cy.get('[data-test="scorecard"]').should("exist");
       });
     });
   });

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -167,6 +167,8 @@ describe("Player for Assessment quizzes", () => {
         fixture: "resume_session.json",
       });
 
+      cy.intercept("PATCH", "/session_answers/*", {});
+
       cy.visit("/abcd?userId=1");
 
       // define aliasas

--- a/tests/e2e/specs/renders-player-homework.js
+++ b/tests/e2e/specs/renders-player-homework.js
@@ -1,6 +1,6 @@
 // https://docs.cypress.io/api/introduction/api.html
 
-describe("Player", () => {
+describe("Player for homework quizzes", () => {
   it("shows 404 error page when quiz ID not provided", () => {
     cy.visit("/");
     cy.url().should("include", "/404-not-found");

--- a/tests/e2e/specs/renders-player.js
+++ b/tests/e2e/specs/renders-player.js
@@ -15,7 +15,7 @@ describe("Player", () => {
     beforeEach(() => {
       // stub the response to /quiz/{quizId}
       cy.intercept("GET", "/quiz/*", {
-        fixture: "quiz.json",
+        fixture: "homework_quiz.json",
       });
     });
 

--- a/tests/unit/components/Questions/Body.spec.ts
+++ b/tests/unit/components/Questions/Body.spec.ts
@@ -78,7 +78,7 @@ describe("Body.vue", () => {
       expect(wrapper.emitted()).toHaveProperty("option-selected");
     });
 
-    it("highlights options based on correct/wrong answers", async () => {
+    it("highlights options based on correct/wrong answers for homework", async () => {
       const submittedAnswer = [0];
       const correctAnswer = [1];
       await wrapper.setProps({
@@ -103,6 +103,27 @@ describe("Body.vue", () => {
         isGradedQuestion: false,
       });
 
+      expect(
+        wrapper.find(`[data-test="optionContainer-0"]`).classes()
+      ).toContain("bg-gray-200");
+    });
+
+    it("highlights options as gray if they are selected for assessment quizzes", async () => {
+      const submittedAnswer = [0];
+      const correctAnswer = [1];
+      await wrapper.setProps({
+        submittedAnswer: submittedAnswer,
+        correctAnswer: correctAnswer,
+        isAnswerSubmitted: true,
+        quizType: "assessment",
+      });
+
+      expect(
+        wrapper.find(`[data-test="optionContainer-1"]`).classes()
+      ).not.toContain("bg-green-500");
+      expect(
+        wrapper.find(`[data-test="optionContainer-0"]`).classes()
+      ).not.toContain("bg-red-500");
       expect(
         wrapper.find(`[data-test="optionContainer-0"]`).classes()
       ).toContain("bg-gray-200");
@@ -160,7 +181,7 @@ describe("Body.vue", () => {
       expect(wrapper.emitted()).toHaveProperty("option-selected");
     });
 
-    it("highlights options based on correct/wrong answers", async () => {
+    it("highlights options based on correct/wrong answers for homework quizzes", async () => {
       const submittedAnswer = [1, 2];
       const correctAnswer = [0, 1];
       await wrapper.setProps({
@@ -188,6 +209,33 @@ describe("Body.vue", () => {
         isGradedQuestion: false,
       });
 
+      expect(
+        wrapper.find('[data-test="optionContainer-1"]').classes()
+      ).toContain("bg-gray-200");
+      expect(
+        wrapper.find('[data-test="optionContainer-2"]').classes()
+      ).toContain("bg-gray-200");
+    });
+
+    it("highlights options as gray if they are selected for assessment quizzes", async () => {
+      const submittedAnswer = [1, 2];
+      const correctAnswer = [0, 1];
+      await wrapper.setProps({
+        submittedAnswer: submittedAnswer,
+        correctAnswer: correctAnswer,
+        isAnswerSubmitted: true,
+        quizType: "assessment",
+      });
+
+      expect(
+        wrapper.find('[data-test="optionContainer-0"]').classes()
+      ).not.toContain("bg-green-500");
+      expect(
+        wrapper.find('[data-test="optionContainer-1"]').classes()
+      ).not.toContain("bg-green-500");
+      expect(
+        wrapper.find('[data-test="optionContainer-2"]').classes()
+      ).not.toContain("bg-red-500");
       expect(
         wrapper.find('[data-test="optionContainer-1"]').classes()
       ).toContain("bg-gray-200");

--- a/tests/unit/components/Questions/Footer.spec.ts
+++ b/tests/unit/components/Questions/Footer.spec.ts
@@ -102,6 +102,11 @@ describe("Footer.vue", () => {
       ).toBeDefined();
     });
 
+    it("clicking on next question button emits continue event", () => {
+      wrapper.find('[data-test="nextQuestionButton"]').trigger("click");
+      expect(wrapper.emitted()).toHaveProperty("continue");
+    });
+
     describe("answer selected", () => {
       beforeEach(async () => {
         await wrapper.setProps({

--- a/tests/unit/components/Questions/Footer.spec.ts
+++ b/tests/unit/components/Questions/Footer.spec.ts
@@ -2,69 +2,132 @@ import { mount } from "@vue/test-utils";
 import Footer from "@/components/Questions/Footer.vue";
 
 describe("Footer.vue", () => {
-  it("shows disabled submit button only by default", () => {
-    const wrapper = mount(Footer);
-    expect(
-      wrapper.get('[data-test="previousQuestionButton"]').classes()
-    ).toContain("hidden");
-    const submitButton = wrapper.find('[data-test="submitButton"]');
-    expect(submitButton.exists()).toBeTruthy();
-    expect(submitButton.text()).toBe("Submit");
-    expect(submitButton.attributes().disabled).toBeDefined();
-    expect(submitButton.classes()).toContain("bg-emerald-500");
-  });
-
-  describe("submit button enabled", () => {
+  describe("Homework quizzes", () => {
     const wrapper = mount(Footer, {
       props: {
-        isSubmitEnabled: true,
+        quizType: "homework",
       },
     });
-
-    it("enables submit button when isSubmitEnabled is set to True", () => {
+    it("shows disabled submit button only by default", () => {
       expect(
-        wrapper.find('[data-test="submitButton"]').attributes().disabled
-      ).not.toBeDefined();
+        wrapper.get('[data-test="previousQuestionButton"]').classes()
+      ).toContain("hidden");
+      const submitButton = wrapper.find('[data-test="submitButton"]');
+      expect(submitButton.exists()).toBeTruthy();
+      expect(submitButton.text()).toBe("Submit");
+      expect(submitButton.attributes().disabled).toBeDefined();
+      expect(submitButton.classes()).toContain("bg-emerald-500");
     });
 
-    it("clicking on submit emits submit event", () => {
-      wrapper.find('[data-test="submitButton"]').trigger("click");
-      expect(wrapper.emitted()).toHaveProperty("submit");
+    describe("submit button enabled", () => {
+      beforeEach(async () => {
+        await wrapper.setProps({
+          isSubmitEnabled: true,
+        });
+      });
+
+      it("enables submit button when isSubmitEnabled is set to True", () => {
+        expect(
+          wrapper.find('[data-test="submitButton"]').attributes().disabled
+        ).not.toBeDefined();
+      });
+
+      it("clicking on submit emits submit event", () => {
+        wrapper.find('[data-test="submitButton"]').trigger("click");
+        expect(wrapper.emitted()).toHaveProperty("submit");
+      });
+    });
+
+    describe("continue button", () => {
+      beforeEach(async () => {
+        await wrapper.setProps({
+          isAnswerSubmitted: true,
+        });
+      });
+
+      it("shows continue instead of submit as button text when answer is submitted", () => {
+        const continueButton = wrapper.find('[data-test="submitButton"]');
+        expect(continueButton.text()).toBe("Continue");
+        expect(continueButton.classes()).toContain("bg-primary");
+      });
+
+      it("clicking on continue button emits continue", () => {
+        wrapper.find('[data-test="submitButton"]').trigger("click");
+        expect(wrapper.emitted()).toHaveProperty("continue");
+      });
+    });
+    describe("previous button", () => {
+      beforeEach(async () => {
+        await wrapper.setProps({
+          isPreviousButtonShown: true,
+        });
+      });
+
+      it("shows previous button when isPreviousButtonShown is true", () => {
+        expect(
+          wrapper.find('[data-test="previousQuestionButton"]').exists()
+        ).toBeTruthy();
+      });
+      it("clicking on previous button emits previous", () => {
+        wrapper.find('[data-test="previousQuestionButton"]').trigger("click");
+        expect(wrapper.emitted()).toHaveProperty("previous");
+      });
     });
   });
 
-  describe("continue button", () => {
+  describe("Assessment quizzes", () => {
     const wrapper = mount(Footer, {
       props: {
-        isAnswerSubmitted: true,
+        quizType: "assessment",
       },
     });
-
-    it("shows continue instead of submit as button text when answer is submitted", () => {
-      const continueButton = wrapper.find('[data-test="submitButton"]');
-      expect(continueButton.text()).toBe("Continue");
-      expect(continueButton.classes()).toContain("bg-primary");
-    });
-
-    it("clicking on continue button emits continue", () => {
-      wrapper.find('[data-test="submitButton"]').trigger("click");
-      expect(wrapper.emitted()).toHaveProperty("continue");
-    });
-  });
-  describe("previous button", () => {
-    const wrapper = mount(Footer, {
-      props: {
-        isPreviousButtonShown: true,
-      },
-    });
-    it("shows previous button when isPreviousButtonShown is true", () => {
+    it("shows next, disabled save & next and disabled clear buttons by default", () => {
       expect(
-        wrapper.find('[data-test="previousQuestionButton"]').exists()
+        wrapper.get('[data-test="previousQuestionButton"]').classes()
+      ).toContain("invisible");
+      expect(wrapper.find('[data-test="submitButton"]').exists()).toBeFalsy();
+      expect(
+        wrapper.find('[data-test="saveAndNextButton"]').exists()
       ).toBeTruthy();
+      expect(wrapper.find('[data-test="clearButton"]').exists()).toBeTruthy();
+      expect(
+        wrapper.find('[data-test="nextQuestionButton"]').exists()
+      ).toBeTruthy();
+
+      expect(
+        wrapper.find('[data-test="clearButton"]').attributes().disabled
+      ).toBeDefined();
+      expect(
+        wrapper.find('[data-test="saveAndNextButton"]').attributes().disabled
+      ).toBeDefined();
     });
-    it("clicking on previous button emits previous", () => {
-      wrapper.find('[data-test="previousQuestionButton"]').trigger("click");
-      expect(wrapper.emitted()).toHaveProperty("previous");
+
+    describe("answer selected", () => {
+      beforeEach(async () => {
+        await wrapper.setProps({
+          isSubmitEnabled: true,
+        });
+      });
+
+      it("enables clear and save & next buttons", () => {
+        expect(
+          wrapper.find('[data-test="clearButton"]').attributes().disabled
+        ).not.toBeDefined();
+        expect(
+          wrapper.find('[data-test="saveAndNextButton"]').attributes().disabled
+        ).not.toBeDefined();
+      });
+
+      it("clicking on clear emits clear event", () => {
+        wrapper.find('[data-test="clearButton"]').trigger("click");
+        expect(wrapper.emitted()).toHaveProperty("clear");
+      });
+
+      it("clicking on save & next emits submit and continue events", () => {
+        wrapper.find('[data-test="saveAndNextButton"]').trigger("click");
+        expect(wrapper.emitted()).toHaveProperty("submit");
+        expect(wrapper.emitted()).toHaveProperty("continue");
+      });
     });
   });
 });

--- a/tests/unit/components/Questions/Footer.spec.ts
+++ b/tests/unit/components/Questions/Footer.spec.ts
@@ -5,8 +5,8 @@ describe("Footer.vue", () => {
   it("shows disabled submit button only by default", () => {
     const wrapper = mount(Footer);
     expect(
-      wrapper.find('[data-test="previousQuestionButton"]').exists()
-    ).toBeFalsy();
+      wrapper.get('[data-test="previousQuestionButton"]').classes()
+    ).toContain("hidden");
     const submitButton = wrapper.find('[data-test="submitButton"]');
     expect(submitButton.exists()).toBeTruthy();
     expect(submitButton.text()).toBe("Submit");

--- a/tests/unit/components/Questions/Header.spec.ts
+++ b/tests/unit/components/Questions/Header.spec.ts
@@ -1,0 +1,14 @@
+import { mount } from "@vue/test-utils";
+import Header from "@/components/Questions/Header.vue";
+
+describe("Header.vue", () => {
+  const wrapper = mount(Header);
+  it("works with default values", () => {
+    expect(wrapper).toBeTruthy();
+  });
+
+  it("emits end-test upon clicking End Test button", () => {
+    wrapper.find('[data-test="endTestButton"]').trigger("click");
+    expect(wrapper.emitted()).toHaveProperty("end-test");
+  });
+});

--- a/tests/unit/components/Questions/QuestionModal.spec.ts
+++ b/tests/unit/components/Questions/QuestionModal.spec.ts
@@ -105,6 +105,18 @@ describe("QuestionModal.vue", () => {
 
       expect(wrapper.vm.localCurrentQuestionIndex).toBe(0);
     });
+
+    describe("Assessments", () => {
+      beforeEach(async () => {
+        await wrapper.setProps({
+          quizType: "assessment",
+        });
+      });
+      it("sets question index to number of questions upon end test", async () => {
+        wrapper.find('[data-test="endTestButton"]').trigger("click");
+        expect(wrapper.vm.localCurrentQuestionIndex).toBe(questions.length);
+      });
+    });
   });
 
   describe("single-choice questions", () => {
@@ -155,6 +167,29 @@ describe("QuestionModal.vue", () => {
           .trigger("click");
 
         expect(wrapper.vm.localCurrentQuestionIndex).toBe(1);
+      });
+    });
+
+    describe("assessments", () => {
+      beforeEach(async () => {
+        await wrapper.setProps({
+          quizType: "assessment",
+        });
+      });
+      it("clears selected answer on clicking Clear", async () => {
+        // select an option
+        wrapper
+          .find('[data-test="body"]')
+          .find('[data-test="option-0"]')
+          .trigger("click");
+
+        wrapper.find('[data-test="clearButton"]').trigger("click");
+
+        expect(
+          wrapper
+            .find('[data-test="body"]')
+            .find('[data-test="optionSelector-0"]').checked
+        ).toBeFalsy();
       });
     });
   });
@@ -226,6 +261,33 @@ describe("QuestionModal.vue", () => {
           .trigger("click");
 
         expect(wrapper.vm.localCurrentQuestionIndex).toBe(2);
+      });
+    });
+
+    describe("assessments", () => {
+      beforeEach(async () => {
+        await wrapper.setProps({
+          quizType: "assessment",
+        });
+      });
+      it("clears selected answer on clicking Clear", async () => {
+        // select an option
+        await wrapper.find('[data-test="option-0"]').trigger("click");
+        // select another option
+        await wrapper.find('[data-test="option-1"]').trigger("click");
+
+        wrapper.find('[data-test="clearButton"]').trigger("click");
+
+        expect(
+          wrapper
+            .find('[data-test="body"]')
+            .find('[data-test="optionSelector-0"]').checked
+        ).toBeFalsy();
+        expect(
+          wrapper
+            .find('[data-test="body"]')
+            .find('[data-test="optionSelector-1"]').checked
+        ).toBeFalsy();
       });
     });
   });

--- a/tests/unit/components/Questions/QuestionModal.spec.ts
+++ b/tests/unit/components/Questions/QuestionModal.spec.ts
@@ -56,6 +56,16 @@ describe("QuestionModal.vue", () => {
       graded: false,
       max_char_limit: 100,
     },
+    {
+      _id: "1239",
+      type: "subjective",
+      text: "yolo",
+      options: null,
+      correct_answer: null,
+      image: null,
+      graded: false,
+      max_char_limit: 100,
+    },
   ] as Question[];
 
   const responses: SubmittedResponse[] = [];
@@ -116,15 +126,11 @@ describe("QuestionModal.vue", () => {
         wrapper.find('[data-test="endTestButton"]').trigger("click");
         expect(wrapper.vm.localCurrentQuestionIndex).toBe(questions.length);
       });
-      it("does not increment question index when next question or save & next button is clicked for last question", () => {
+      it("does not increment question index when save & next button is clicked for last question", () => {
         for (let index = 0; index < questions.length - 1; index++) {
           wrapper.find('[data-test="nextQuestionButton"]').trigger("click");
         }
         // ensure that the last question has been reached
-        expect(wrapper.vm.localCurrentQuestionIndex).toBe(questions.length - 1);
-
-        wrapper.find('[data-test="nextQuestionButton"]').trigger("click");
-        // the question index should not have been updated
         expect(wrapper.vm.localCurrentQuestionIndex).toBe(questions.length - 1);
 
         wrapper.find('[data-test="saveAndNextButton"]').trigger("click");

--- a/tests/unit/components/Splash.spec.ts
+++ b/tests/unit/components/Splash.spec.ts
@@ -17,7 +17,7 @@ describe("Splash.vue", () => {
     },
   });
 
-  it("renders title correctly", () => {
+  it("renders props correctly", () => {
     expect(wrapper.find('[data-test="title"]').text()).toBe(title);
     expect(wrapper.find('[data-test="subject"]').text()).toBe(subject);
     expect(wrapper.find('[data-test="quizType"]').text()).toBe(quizType);

--- a/tests/unit/components/Splash.spec.ts
+++ b/tests/unit/components/Splash.spec.ts
@@ -4,7 +4,7 @@ import Splash from "@/components/Splash.vue";
 describe("Splash.vue", () => {
   const title = "Geometry Quiz";
   const subject = "Maths";
-  const quizType = "CBSE";
+  const quizType = "assessment";
   const numQuestions = 3;
   const grade = "8";
   const wrapper = mount(Splash, {

--- a/tests/unit/components/UI/Progress/CircularProgress.spec.ts
+++ b/tests/unit/components/UI/Progress/CircularProgress.spec.ts
@@ -2,11 +2,6 @@ import { mount } from "@vue/test-utils";
 import CircularProgress from "@/components/UI/Progress/CircularProgress.vue";
 
 describe("CircularProgress.vue", () => {
-  it("renders properly with default values", () => {
-    const wrapper = mount(CircularProgress);
-    expect(wrapper).toBeTruthy();
-  });
-
   it("computed properties are created properly", () => {
     const radius = 100;
     const progress = 75;


### PR DESCRIPTION
Fixes #36 

Linked to: https://github.com/avantifellows/quiz-backend/pull/33
Mockup [here](https://www.figma.com/proto/bq4eFJDMaTTaZPy5bFjMPg/Quiz-type%3A-Assessments?node-id=1%3A871&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=1%3A418&show-proto-sidebar=1).

## Summary
- new interface for `quizType = assessment`
- updated the general font of the app
- updated the scorecard to simplify the styling and get it to match that of Plio
- added number of skipped questions to be shown in the scorecard
- added `vue-toastification` to show a toast when the viewer is on the last question and pressing the right arrow button or the `Save & Next` button
- added API endpoint to update Sessions
- added new variable to track whether the quiz has ended because for assessments, viewers have to specifically click "End Test"
- separated e2e tests for homework and assessment quizzes

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Test Responsiveness
  - [x] Laptop (1200px)
  - [x] Tablet (760px)
  - [x] Phone (320px)
- [x] Cross-Browser Testing
  - [x] Chrome
  - [x] Firefox
- [ ] ~Local Language Support~
- [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [ ] ~Check for bundle size [here](https://bundlephobia.com/) if adding a package~
  - [x] Added relevant details like Labels/Projects/Milestones etc.
  - [ ] ~If adding or removing any environment variable, update `docs/ENV.md`, `.env.example` and the Github workflows.~
- [ ] Testing
  - [x] Wrote tests
  - [x] Tested locally
  - [x] Tested on staging
  - [ ] Tested on an actual physical phone
  - [ ] Tested on production
- [x] Lighthouse Checks
  - [ ] ~Images have `alt` attributes~
  - [ ] ~Any `<img>` tags have `width` and `height` specified~
  - [ ] ~Any `target="_blank"` links have `rel="noopener"`~
  - [x] Only SVGs are used as images. If PNGs are used, their size has been optimised.
  - [x] Any SVG buttons without text have their `aria-label` attributes set
